### PR TITLE
Explain templates and jsPsych version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The team takes responsibility for fixing bugs and updating plugins to take advan
 Plugins and extensions in this repository are contributed by community members. 
 They are not extensively tested or verified by the core jsPsych team. 
 
-Contributions to `jspsych-contrib` that are broadly useful, well-documented, and-well tested may be added to the main `jsPsych` repository, with the contributor's permission.
+Contributions to `jspsych-contrib` that are broadly useful, well-documented, and well-tested may be added to the main `jsPsych` repository, with the contributor's permission.
 
 ## Guidelines for contributions
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # jspsych-contrib: jsPsych community contributions
 
-This is an open repository of jsPsych plugins and extensions developed by members of the jsPsych community.
+This is an open repository of jsPsych plugins and extensions developed by members of the jsPsych community. If you've written a jsPsych plugin or extension that you think others might be interested in using, this is the place to share it!
 
 ## `jspsych` vs. `jspsych-contrib` 
 
-Plugins and extensions in the [main jspsych repository](https://github.com/jspsych/jsPsych/) are maintained by the core jsPsych team. 
+Plugins and extensions in the [main `jsPsych` repository](https://github.com/jspsych/jsPsych/) are maintained by the core jsPsych team. 
 The team takes responsibility for fixing bugs and updating plugins to take advantage of new features in jsPsych. 
 
-Plugins and extensions in this repository are contributed by community members. 
-They are not extensively tested or verified by the core jsPsych team. 
+Plugins and extensions in this `jspsych-contrib` repository are contributed by community members. 
+They are not extensively tested or verified by the core jsPsych team, and there is no guarantee that anyone will be available to fix bugs, push updates, or answer questions about these plugins/extensions.
+However we would encourage contributors to respond to issues/questions and to maintain their code.
 
 Contributions to `jspsych-contrib` that are broadly useful, well-documented, and well-tested may be added to the main `jsPsych` repository, with the contributor's permission.
 
@@ -28,28 +29,52 @@ Optionally, contributions can include:
 * A test suite following the testing framework in our `-ts` templates.
 
 
-To submit a contribution, [open a pull request](https://github.com/jspsych/jspsych-contrib/pulls).
-In the pull request, please make it clear how we can verify that the contribution is functional. 
+To submit a contribution, [open a pull request](https://github.com/jspsych/jspsych-contrib/pulls) that contains a directory for your plugin/extension inside the `/packages` directory.
+In the pull request comments, please make it clear how we can verify that the contribution is functional. 
 This could be accomplished with a link to a demonstration experiment, the inclusion of an example file and/or testing files, or through some other means.
 We try to review pull requests quickly and add new contributions as soon as the minimal standards are met.
 
 ## Plugin templates
 
-There are two plugin template directories inside the `/packages` directory that you can as a reference when creating a directory for your plugin contribution. Both templates are compatible with jsPsych v7+.
+There are two plugin template directories inside the `/packages` directory that you can use as a reference when creating a directory for your plugin contribution. 
+Both templates are compatible with jsPsych v7+.
 
-* `plugin-template-ts`: This template uses TypeScript source files that are complied into JavaScript using Node.js and npm.
-  This is the format used for plugins in the main jsPsych repo.
-  For more details, including setup instructions, please see the jsPsych documentation page [Configuring the jsPsych development environment](https://www.jspsych.org/latest/developers/configuration).
-* `plugin-template`: This template allows you to put your plugin's JavaScript code directly into a JavaScript template file, rather than using TypeScript and Node.js/npm. 
+Regardless of which template you use, you can get started by creating a copy of the template folder in `/packages` and renaming it according to your plugin/extension name. Be sure that you also:
+* Edit the `package.json` file
+* Add a readme.md file to your plugin/extension directory, based on the [readme template](readme-template.md)
+
+### `plugin-template-ts`
+
+This template uses TypeScript source files that are complied into JavaScript using Node.js and npm.
+This is the format used for plugins in the main jsPsych repo.
+To use this template, you should edit the `src/index.ts` file, keeping the overall structure but changing the details as appropriate (plugin name, parameters, trial method, etc.).
+You can then use the `npm run build` command to compile your `index.ts` code into JavaScript files, which will appear in a `/dist` directory.
+This format also allows you to add a Jest test file (optional), which you can create based on the `src/index.spec.ts` template file.
+
+In the `rollup.config.mjs` file, replace "jsPsychPluginName" with your plugin name (same as the class name in the `index.ts` file).
+You do not need to edit the other config files in this template directory.
+
+For more details, including setup instructions and detailed explanations of files, please see the jsPsych documentation page: [Configuring the jsPsych development environment](https://www.jspsych.org/latest/developers/configuration).
+You can also look at the plugin/extension folders in the main jsPsych repository `/packages` directory for more examples.
+
+### `plugin-template`
+
+This template allows you to put your plugin's JavaScript code directly into a JavaScript template file, rather than using TypeScript and Node.js/npm. 
+To use this template, you should keep the overall structure of the `index.js` file, but change the details as appropriate for your plugin (plugin name, parameters, etc.).
+The JavaScript code that runs the trial goes inside the `trial` method for the plugin class.
 
 ## jsPsych version compatibility
 
-We would like to encourage you to contribute plugins that are compatible with the latest jsPsych version. At the same time, we realize that there may be jsPsych users who have created very useful plugins with jsPsych v6 that they would like to share with the community, but don't have the time/resources to convert into the jsPsych v7+ Node package format. Therefore we welcome plugins that are compatible with v6 as well as v7+. 
+We would like to encourage you to contribute plugins and extensions that are compatible with the latest jsPsych version. 
+At the same time, we realize that there may be jsPsych users who have created very useful plugins/extensions with jsPsych v6 that they would like to share with the community, but don't have the time/resources to convert into the jsPsych v7+ Node package format. 
+Therefore we welcome contributions that are compatible with v6 as well as v7+. 
 
-If you'd like to contribute a jsPsych v6 plugin, please do the following:
+If you'd like to contribute a **jsPsych v6 plugin**, please do the following:
 * Use the `plugin-template` directory as a reference
 * Delete everything inside of the `index.js` template file and replace it with your v6-compatible plugin code
+* In the `package.json` file, change the "jspsych" version field in "devDependencies" to "6.3.1"
+
+And remember to follow the other steps for contributing:
 * Edit the `package.json` file with the information about your plugin
-* Delete the "devDependencies" property and values in the `package.json` files (this is only relevant for plugins that are compatible with jsPsych v7+)
-* Add a `readme.md` file, which must state the jsPsych version that your plugin is compatible with
+* Add a `readme.md` file for your plugin, based on the [readme template](https://github.com/jspsych/jspsych-contrib/blob/main/readme-template.md). This must state the jsPsych version that your plugin is compatible with.
 * Optional: add a `/docs` directory with a markdown documentation file, and/or `/examples` directory with an HTML example file

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ We try to review pull requests quickly and add new contributions as soon as the 
 
 There are two plugin template directories inside the `/packages` directory that you can as a reference when creating a directory for your plugin contribution. Both templates are compatible with jsPsych v7+.
 
-* `plugin-template-ts`: This template uses TypeScript source files that are complied into JavaScript using Node.js and npm. This is the format used for plugins in the main jsPsych repo. For more details, please see the jsPsych documentation page [Configuring the jsPsych development environment](https://www.jspsych.org/developers/configuration).
+* `plugin-template-ts`: This template uses TypeScript source files that are complied into JavaScript using Node.js and npm.
+  This is the format used for plugins in the main jsPsych repo.
+  For more details, including setup instructions, please see the jsPsych documentation page [Configuring the jsPsych development environment](https://www.jspsych.org/latest/developers/configuration).
 * `plugin-template`: This template allows you to put your plugin's JavaScript code directly into a JavaScript template file, rather than using TypeScript and Node.js/npm. 
 
 ## jsPsych version compatibility

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The team takes responsibility for fixing bugs and updating plugins to take advan
 Plugins and extensions in this repository are contributed by community members. 
 They are not extensively tested or verified by the core jsPsych team. 
 
-Contributions to `jspsych-contrib` that are broadly useful, well documented, and well tested may be added to the main repository, with the contributor's permission.
+Contributions to `jspsych-contrib` that are broadly useful, well-documented, and-well tested may be added to the main `jsPsych` repository, with the contributor's permission.
 
 ## Guidelines for contributions
 
@@ -33,3 +33,21 @@ In the pull request, please make it clear how we can verify that the contributio
 This could be accomplished with a link to a demonstration experiment, the inclusion of an example file and/or testing files, or through some other means.
 We try to review pull requests quickly and add new contributions as soon as the minimal standards are met.
 
+## Plugin templates
+
+There are two plugin template directories inside the `/packages` directory that you can as a reference when creating a directory for your plugin contribution. Both templates are compatible with jsPsych v7+.
+
+* `plugin-template-ts`: This template uses TypeScript source files that are complied into JavaScript using Node.js and npm. This is the format used for plugins in the main jsPsych repo. For more details, please see the jsPsych documentation page [Configuring the jsPsych development environment](https://www.jspsych.org/developers/configuration).
+* `plugin-template`: This template allows you to put your plugin's JavaScript code directly into a JavaScript template file, rather than using TypeScript and Node.js/npm. 
+
+## jsPsych version compatibility
+
+We would like to encourage you to contribute plugins that are compatible with the latest jsPsych version. At the same time, we realize that there may be jsPsych users who have created very useful plugins with jsPsych v6 that they would like to share with the community, but don't have the time/resources to convert into the jsPsych v7+ Node package format. Therefore we welcome plugins that are compatible with v6 as well as v7+. 
+
+If you'd like to contribute a jsPsych v6 plugin, please do the following:
+* Use the `plugin-template` directory as a reference
+* Delete everything inside of the `index.js` template file and replace it with your v6-compatible plugin code
+* Edit the `package.json` file with the information about your plugin
+* Delete the "devDependencies" property and values in the `package.json` files (this is only relevant for plugins that are compatible with jsPsych v7+)
+* Add a `readme.md` file, which must state the jsPsych version that your plugin is compatible with
+* Optional: add a `/docs` directory with a markdown documentation file, and/or `/examples` directory with an HTML example file

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ We try to review pull requests quickly and add new contributions as soon as the 
 There are two plugin template directories inside the `/packages` directory that you can use as a reference when creating a directory for your plugin contribution. 
 Both templates are compatible with jsPsych v7+.
 
-Regardless of which template you use, you can get started by creating a copy of the template folder in `/packages` and renaming it according to your plugin/extension name. Be sure that you also:
+Regardless of which template you use, you can get started by creating a copy of the template folder in `/packages` and renaming it according to your plugin/extension name. 
+You may also want to read the jsPsych documentation on [plugin development](https://www.jspsych.org/latest/developers/plugin-development/) to understand how to work with the `index.ts`file (in `plugin-template-ts`) and `index.js` file (in `plugin-template`).
+In your plugin/extension folder, be sure that you also:
 * Edit the `package.json` file
 * Add a readme.md file to your plugin/extension directory, based on the [readme template](readme-template.md)
 
@@ -51,17 +53,18 @@ To use this template, you should edit the `src/index.ts` file, keeping the overa
 You can then use the `npm run build` command to compile your `index.ts` code into JavaScript files, which will appear in a `/dist` directory.
 This format also allows you to add a Jest test file (optional), which you can create based on the `src/index.spec.ts` template file.
 
-In the `rollup.config.mjs` file, replace "jsPsychPluginName" with your plugin name (same as the class name in the `index.ts` file).
+In the `rollup.config.mjs` file, replace "jsPsychPluginName" with your plugin name.
 You do not need to edit the other config files in this template directory.
 
 For more details, including setup instructions and detailed explanations of files, please see the jsPsych documentation page: [Configuring the jsPsych development environment](https://www.jspsych.org/latest/developers/configuration).
-You can also look at the plugin/extension folders in the main jsPsych repository `/packages` directory for more examples.
+You can also read the [plugin development documentation](https://www.jspsych.org/latest/developers/plugin-development/) and look at the plugin/extension folders in the main jsPsych repository `/packages` directory for more examples.
 
 ### `plugin-template`
 
 This template allows you to put your plugin's JavaScript code directly into a JavaScript template file, rather than using TypeScript and Node.js/npm. 
 To use this template, you should keep the overall structure of the `index.js` file, but change the details as appropriate for your plugin (plugin name, parameters, etc.).
 The JavaScript code that runs the trial goes inside the `trial` method for the plugin class.
+More information about working with the `index.js` file can be found in the [plugin development documentation](https://www.jspsych.org/latest/developers/plugin-development/).
 
 ## jsPsych version compatibility
 

--- a/readme-template.md
+++ b/readme-template.md
@@ -24,7 +24,7 @@ import { jsPsychPluginName } from '@jspsych-contrib/my-package-name';
 
 ## Compatibility
 
-Please state which jsPsych version your plugin was developed for use with: jsPsych v7.0.0 or jsPsych v6.x.x (give specific version). 
+Please state which jsPsych version your plugin was developed for use with: "jsPsych v7.x.x" or "jsPsych v6.x.x" (give specific version). 
 
 ## Documentation
 

--- a/readme-template.md
+++ b/readme-template.md
@@ -24,7 +24,7 @@ import { jsPsychPluginName } from '@jspsych-contrib/my-package-name';
 
 ## Compatibility
 
-jsPsych v7.0.
+Please state which jsPsych version your plugin was developed for use with: jsPsych v7.0.0 or jsPsych v6.x.x (give specific version). 
 
 ## Documentation
 


### PR DESCRIPTION
Some initial suggestions for changes to the main `readme` file to explain the difference between the two plugin templates, and to add a note about jsPsych version compatibility. Also edited the `readme-template` file to add the option of jsPsych v6 compatibility.

Happy to add more details about using the plugin templates, etc. 

Feedback and edits welcome!