### PR TITLE
RDK performance optimizations

### DIFF
--- a/.changeset/big-poems-design.md
+++ b/.changeset/big-poems-design.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-rdk": minor
+---
+
+This version improves drawing performance through batching and simplified canvas clearing. It also introduces a new `dot_shape` parameter to allow drawing squares instead of circles, which can further reduce drawing time.

--- a/packages/plugin-rdk/docs/jspsych-rdk.md
+++ b/packages/plugin-rdk/docs/jspsych-rdk.md
@@ -25,12 +25,14 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | coherent_direction       | numeric          | 0                    | The direction of movement for coherent dots in degrees. 0 degrees is in the 3 o'clock direction, and increasing this number moves counterclockwise. (E.g. 12 o'clock is 90, 9 o'clock is 180, etc.) Range is 0 - 360. |
 | coherence                | numeric          | 0.5                  | The proportion of dots that move together in the coherent direction. Range is 0 to 1. |
 | opposite_coherence       | numeric          | 0                    | The proportion of moving in the direction opposite of the coherent direction. Range is 0 to (1-coherence). |
-| dot_radius               | numeric          | 2                    | The radius of each individual dot in pixels. |
+| dot_radius               | numeric          | 2                    | The radius of each individual dot in pixels (only used when `dot_shape` is "circle"). |
+| dot_side_length          | numeric          | 1                    | The length of the dot's side in pixels (only used when `dot_shape` is "square"). |
 | dot_life                 | numeric          | -1                   | The number of frames that pass before a dot disappears and reappears in a new frame. -1 denotes that the dot life is infinite (i.e., a dot will only disappear and reappear if it moves out of the aperture). |
 | move_distance            | numeric          | 1                    | The number of pixel lengths the dot will move in each frame (analogous to speed of dots). |
 | aperture_width           | numeric          | 600                  | The width of the aperture in pixels. For a square aperture, this will determine both the width and height. For circular aperture, this will determine the diameter. |
 | aperture_height          | numeric          | 400                  | The height of the aperture in pixels. For square and circle apertures, this will be ignored. |
 | dot_color                | string           | "white"              | The color of the dots.                   |
+| dot_shape                | string           | "circle"             | The shape of the dots (either "circle" or "square"). Squares are significantly faster to draw, and may be indistinguishable from circles when the dot size is small. |
 | background_color         | string           | "gray"               | The color of the background.             |
 | RDK_type                 | numeric          | 3                    | The Signal Selection Rule (Same/Different) and Noise Type (Random Position/Walk/Direction):<br><br>1 - Same && Random Position<br>2 - Same && Random Walk<br>3 - Same && Random Direction<br>4 - Different && Random Position<br>5 - Different && Random Walk<br>6 - Different && Random Direction<br><br>(See 'RDK parameter' below for more detailed information)<br> |
 | aperture_type            | numeric          | 2                    | The shape of the aperture.<br><br>1 - Circle<br>2 - Ellipse<br>3 - Square<br>4 - Rectangle<br> |

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -880,13 +880,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       //Three for loops that do things in sequence: clear, update, and draw dots.
 
       // Clear all the current dots
-      for (currentApertureNumber = 0; currentApertureNumber < nApertures; currentApertureNumber++) {
-        //Initialize the variables for each parameter
-        initializeCurrentApertureParameters(currentApertureNumber);
-
-        //Clear the canvas by drawing over the current dots
-        clearDots();
-      }
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       // Update all the relevant dots
       for (currentApertureNumber = 0; currentApertureNumber < nApertures; currentApertureNumber++) {
@@ -905,20 +899,19 @@ class RdkPlugin implements JsPsychPlugin<Info> {
         //Draw on the canvas
         draw();
       }
-    }
-
-    //Function that clears the dots on the canvas by drawing over it with the color of the baclground
-    function clearDots() {
-      //Load in the current set of dot array for easy handling
-      var dotArray = dotArray2d[currentSetArray[currentApertureNumber]];
-
-      //Loop through the dots one by one and draw them
-      for (var i = 0; i < nDots; i++) {
-        const dot = dotArray[i];
+      //Draw the fixation cross if we want it
+      if (fixationCross === true) {
+        //Horizontal line
         ctx.beginPath();
-        ctx.arc(dot.x, dot.y, dotRadius + 1, 0, Math.PI * 2);
-        ctx.fillStyle = backgroundColor;
-        ctx.fill();
+        ctx.lineWidth = fixationCrossThickness;
+        ctx.moveTo(canvasWidth / 2 - fixationCrossWidth, canvasHeight / 2);
+        ctx.lineTo(canvasWidth / 2 + fixationCrossWidth, canvasHeight / 2);
+
+        //Vertical line
+        ctx.moveTo(canvasWidth / 2, canvasHeight / 2 - fixationCrossHeight);
+        ctx.lineTo(canvasWidth / 2, canvasHeight / 2 + fixationCrossHeight);
+        ctx.strokeStyle = fixationCrossColor;
+        ctx.stroke();
       }
     }
 
@@ -938,25 +931,6 @@ class RdkPlugin implements JsPsychPlugin<Info> {
         ctx.arc(dot.x, dot.y, dotRadius, 0, pi2);
       }
       ctx.fill();
-
-      //Draw the fixation cross if we want it
-      if (fixationCross === true) {
-        //Horizontal line
-        ctx.beginPath();
-        ctx.lineWidth = fixationCrossThickness;
-        ctx.moveTo(canvasWidth / 2 - fixationCrossWidth, canvasHeight / 2);
-        ctx.lineTo(canvasWidth / 2 + fixationCrossWidth, canvasHeight / 2);
-        ctx.strokeStyle = fixationCrossColor;
-        ctx.stroke();
-
-        //Vertical line
-        ctx.beginPath();
-        ctx.lineWidth = fixationCrossThickness;
-        ctx.moveTo(canvasWidth / 2, canvasHeight / 2 - fixationCrossHeight);
-        ctx.lineTo(canvasWidth / 2, canvasHeight / 2 + fixationCrossHeight);
-        ctx.strokeStyle = fixationCrossColor;
-        ctx.stroke();
-      }
 
       //Draw the border if we want it
       if (border === true) {

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -99,6 +99,12 @@ const info = <const>{
       pretty_name: "Dot color",
       default: "white",
     },
+    /** The shape of the dots */
+    dot_shape: {
+      type: ParameterType.INT,
+      pretty_name: "Dot shape",
+      default: 1,
+    },
     /** The background color of the stimulus. */
     background_color: {
       type: ParameterType.STRING,
@@ -248,6 +254,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
     var aperture_width = assignParameterValue(trial.aperture_width, 600);
     var aperture_height = assignParameterValue(trial.aperture_height, 400);
     var dot_color = assignParameterValue(trial.dot_color, "white");
+    var dot_shape = assignParameterValue(trial.dot_shape, 1);
     var background_color = assignParameterValue(trial.background_color, "gray");
     var RDK_type = assignParameterValue(trial.RDK_type, 3);
     var aperture_type = assignParameterValue(trial.aperture_type, 2);
@@ -320,6 +327,13 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       4 - Rectangle
       */
     var apertureType = aperture_type;
+
+    /**
+      Shape of dots
+      1 - Circle
+      3 - Square
+      */
+    var dotShape = dot_shape;
 
     /*
       Out of Bounds Decision
@@ -406,6 +420,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
     var apertureWidthArray;
     var apertureHeightArray;
     var dotColorArray;
+    var dotShapeArray;
     var apertureCenterXArray;
     var apertureCenterYArray;
     var RDKArray;
@@ -433,6 +448,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       apertureWidthArray = setParameter(apertureWidth);
       apertureHeightArray = setParameter(apertureHeight);
       dotColorArray = setParameter(dotColor);
+      dotShapeArray = setParameter(dotShape);
       apertureCenterXArray = setParameter(apertureCenterX);
       apertureCenterYArray = setParameter(apertureCenterY);
       RDKArray = setParameter(RDK);
@@ -705,6 +721,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       apertureWidth = apertureWidthArray[currentApertureNumber];
       apertureHeight = apertureHeightArray[currentApertureNumber];
       dotColor = dotColorArray[currentApertureNumber];
+      dotShape = dotShapeArray[currentApertureNumber];
       apertureCenterX = apertureCenterXArray[currentApertureNumber];
       apertureCenterY = apertureCenterYArray[currentApertureNumber];
       RDK = RDKArray[currentApertureNumber];
@@ -922,13 +939,21 @@ class RdkPlugin implements JsPsychPlugin<Info> {
 
       const pi2 = Math.PI * 2;
 
+      const circleFn = (x, y, rad) => {
+        ctx.arc(x, y, rad, 0, pi2);
+      };
+      const rectFn = (x, y, rad) => {
+        ctx.rect(x, y, rad * 2, rad * 2);
+      };
+      const drawFn = dotShape == 3 ? rectFn : circleFn;
+
       //Loop through the dots one by one and draw them
       ctx.fillStyle = dotColor;
       ctx.beginPath();
       for (var i = 0; i < nDots; i++) {
         const dot = dotArray[i];
         ctx.moveTo(dot.x + dotRadius, dot.y);
-        ctx.arc(dot.x, dot.y, dotRadius, 0, pi2);
+        drawFn(dot.x, dot.y, dotRadius);
       }
       ctx.fill();
 

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -927,14 +927,17 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       //Load in the current set of dot array for easy handling
       var dotArray = dotArray2d[currentSetArray[currentApertureNumber]];
 
+      const pi2 = Math.PI * 2;
+
       //Loop through the dots one by one and draw them
+      ctx.fillStyle = dotColor;
+      ctx.beginPath();
       for (var i = 0; i < nDots; i++) {
         const dot = dotArray[i];
-        ctx.beginPath();
-        ctx.arc(dot.x, dot.y, dotRadius, 0, Math.PI * 2);
-        ctx.fillStyle = dotColor;
-        ctx.fill();
+        ctx.moveTo(dot.x + dotRadius, dot.y);
+        ctx.arc(dot.x, dot.y, dotRadius, 0, pi2);
       }
+      ctx.fill();
 
       //Draw the fixation cross if we want it
       if (fixationCross === true) {

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -524,6 +524,15 @@ class RdkPlugin implements JsPsychPlugin<Info> {
     //variable to store how many frames were presented.
     var numberOfFrames = 0;
 
+    // set up dot-drawing abstractions
+    const pi2 = Math.PI * 2;
+    const circleFn = (x, y, rad) => {
+      ctx.arc(x, y, rad, 0, pi2);
+    };
+    const rectFn = (x, y, rad) => {
+      ctx.rect(x, y, rad * 2, rad * 2);
+    };
+
     //Function to start the keyboard listener
     const startKeyboardListener = () => {
       //Start the response listener if there are choices for keys
@@ -937,14 +946,6 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       //Load in the current set of dot array for easy handling
       var dotArray = dotArray2d[currentSetArray[currentApertureNumber]];
 
-      const pi2 = Math.PI * 2;
-
-      const circleFn = (x, y, rad) => {
-        ctx.arc(x, y, rad, 0, pi2);
-      };
-      const rectFn = (x, y, rad) => {
-        ctx.rect(x, y, rad * 2, rad * 2);
-      };
       const drawFn = dotShape == 3 ? rectFn : circleFn;
 
       //Loop through the dots one by one and draw them
@@ -971,7 +972,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
             verticalAxis + borderThickness / 2,
             0,
             0,
-            Math.PI * 2
+            pi2
           );
           ctx.stroke();
         } //End of if circle or ellipse

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -530,7 +530,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       ctx.arc(x, y, rad, 0, pi2);
     };
     const rectFn = (x, y, rad) => {
-      ctx.rect(x, y, rad * 2, rad * 2);
+      ctx.rect(x - rad, y - rad, rad * 2, rad * 2);
     };
 
     //Function to start the keyboard listener

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -535,10 +535,10 @@ class RdkPlugin implements JsPsychPlugin<Info> {
 
     // set up dot-drawing abstractions
     const pi2 = Math.PI * 2;
-    const circleFn = (x, y, rad) => {
+    const circleFn = (x: number, y: number, rad: number) => {
       ctx.arc(x, y, rad, 0, pi2);
     };
-    const squareFn = (x, y, half_len) => {
+    const squareFn = (x: number, y: number, half_len: number) => {
       const len = half_len * 2;
       ctx.rect(x - half_len, y - half_len, len, len);
     };
@@ -605,6 +605,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
         aperture_width: aperture_width,
         aperture_height: aperture_height,
         dot_color: dot_color,
+        dot_shape: dot_shape,
         background_color: background_color,
         RDK_type: RDK_type,
         aperture_type: aperture_type,


### PR DESCRIPTION
Hello,

These are a few changes to the RDK plugin to improve performance, particularly when there are more than a few hundred dots or on slower hardware.

 - Batched dot drawing. Rather than having a `beginPath()`/`fill()` pair per dot, wait to fill until the end.
 - Simplified dot clearing. All visuals seem to be redrawn each frame, so opted for `clearRect()` rather than drawing over individual dots.
 - Moved the fixation cue outside of `draw()`. Probably not a big deal, but it doesn't seem to be used per-aperture, and so would be unnecessarily redrawn for each aperture.
 - Introduced a `dot_shape` parameter, which allows squares to be substituted for circles in cases when dots are small. Squares can be drawn significantly faster.

For testing, I changed the number of dots in example4.html to `[500, 200, 100]`.

On my desktop (Ubuntu 20.04, RX 580 GPU, Chromium), this reduced the reported CPU time (which seems to wait for the GPU to finish) for the frame from ~9.5ms to ~4.5ms, and on my laptop (Ubuntu 18.04, Intel GPU, Chromium) from ~25ms to ~6.5ms. Changing the dot shape to square further improves performance (e.g. on desktop, from 4.5ms to ~2.75ms).

I haven't changed any documentation yet because some details still need to be fleshed out:

 - If `dot_shape` + square is desirable, should it share `dot_radius` with the circle shape or should it have a separate parameter to allow smaller shapes/should `dot_radius` be allowed to be fractional?
 - Should available `dot_shapes` match the integers used for `aperture_type`, i.e. 1 for circle and 3 for square?
 - Should code target ES5 or 6+? I tried to match style in some places, but also used `const` + arrow functions...

Hope this is useful!
