### PR TITLE
Adding html-vas-response

### DIFF
--- a/.changeset/few-turtles-pretend.md
+++ b/.changeset/few-turtles-pretend.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-html-vas-response": major
+---
+
+Initial release

--- a/packages/plugin-html-vas-response/README.md
+++ b/packages/plugin-html-vas-response/README.md
@@ -1,0 +1,27 @@
+# html-vas-response
+
+## Overview
+
+This plugin collects responses to an arbitrary HTML string using a point-and-click visual analogue scale.
+
+## Loading
+
+```js
+<script src="plugin-html-vas-response/index.js">
+```
+
+## Compatibility
+
+jsPsych v7.0
+
+## Documentation
+
+See [documentation](docs/jspsych-html-vas-response.md)
+
+## Author / Citation
+
+Created by [Isaac Kinley](https://github.com/kinleyid)
+
+Citation:
+
+Kinley, I. (2022, March 7). "A jsPsych plugin for visual analogue scales." Retrieved from psyarxiv.com/avj92. DOI: 10.31234/osf.io/avj92

--- a/packages/plugin-html-vas-response/README.md
+++ b/packages/plugin-html-vas-response/README.md
@@ -25,4 +25,4 @@ Created by [Isaac Kinley](https://github.com/kinleyid)
 
 Citation:
 
-Kinley, I. (2022, March 7). "A jsPsych plugin for visual analogue scales." Retrieved from psyarxiv.com/avj92. DOI: 10.31234/osf.io/avj92
+Kinley, I. (2022, March 7). "A jsPsych plugin for visual analogue scales." Retrieved from https://psyarxiv.com/avj92. DOI: 10.31234/osf.io/avj92

--- a/packages/plugin-html-vas-response/README.md
+++ b/packages/plugin-html-vas-response/README.md
@@ -7,7 +7,8 @@ This plugin collects responses to an arbitrary HTML string using a point-and-cli
 ## Loading
 
 ```js
-<script src="plugin-html-vas-response/index.js">
+<script src="https://unpkg.com/@jspsych-contrib/plugin-libet-intentional-binding@1.0.0">
+
 ```
 
 ## Compatibility

--- a/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
+++ b/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
@@ -1,0 +1,50 @@
+# jspsych-html-vas-response plugin
+
+This plugin collects responses to an arbitrary HTML string using a point-and-click visual analogue scale.
+
+## Citation
+
+Kinley, I. (2022, March 7). "A jsPsych plugin for visual analogue scales." Retrieved from psyarxiv.com/avj92. DOI: 10.31234/osf.io/avj92
+
+## Parameters
+
+In addition to the [parameters available in all plugins](https://www.jspsych.org/overview/plugins#parameters-available-in-all-plugins), this plugin accepts the following parameters. Parameters with a default value of *undefined* must be specified. Parameters can be left unspecified if the default value is acceptable.
+
+| Parameter                | Type             | Default Value        | Descripton                               |
+| ------------------------ | ---------------- | -------------------- | ---------------------------------------- |
+| stimulus                     | HTML string           | `undefined`     | The string to be displayed. |
+| labels                     | array of strings           | `[]`     | Specifies the labels to be displayed, equally spaced along the scale, as in jspsych-html-slider-response. |
+| ticks                     | Boolean           | `true`     | Specifies whether smaller vertical tick marks should accompany the labels. |
+| scale_width | integer | `null` |  The width of the VAS in pixels. If left null, then the width will be equal to the widest element in the display. |
+| scale_height | integer | 40 | The height of the clickable region around the VAS in pixels. |
+| scale_colour | string | `'black'` | The colour of the scale (the horizontal line). Anything that would make a valid CSS `background` property can be used here; e.g., `'linear-gradient(to right, blue, red)'` |
+| scale_cursor | string | `'pointer'` | The style of the cursor when the clickable part of the scale is hovered over. |
+| marker_colour | string | `'rgba(0, 0, 0, 0.5)'` | The colour of the participant's response marker. Anything that would make a valid CSS `background` property can be used here; e.g., `'linear-gradient(to top, blue, red)'` |
+| tick_colour | string | `'black'` | The colour of the tick marks on the scale. Anything that would make a valid CSS `background` property can be used here; e.g., `'rgba(255, 0, 0, 0.8)'` |
+| prompt | HTML string | `null` | The content to be displayed below the stimulus. |
+| button_label | string | `'Continue'` | The text of the button that will submit the response. |
+| required | Boolean | `false` | If `true`, the participant must select a response on the VAS before the trial can advance. |
+| stimulus_duration | integer | `null` | The duration, in milliseconds, for which the stimulus is visible. If `null`, the stimulus is visible for the duration of the trial. |
+| trial_duration | integer | `null` | The duration of the trial, in milliseconds. Once this time elapses, the trial ends and any response is recorded. If `null`, the trial continues indefinitely. |
+| response_ends_trial | Boolean | `true` | If `false`, the participant's clicking the continue button does not end the trial (but does prevent any changes to the VAS response), and the trial ends when `trial_duration` has elapsed. |
+
+## Data Generated
+
+In addition to the [default data collected by all plugins](https://www.jspsych.org/overview/plugins#data-collected-by-all-plugins), this plugin collects all parameter data described above and the following data for each trial.
+
+| Name             | Type        | Value                                    |
+| ---------------- | ----------- | ---------------------------------------- |
+| response             | numeric      | The value selected, between 0 and 1. 0 is the leftmost point on the scale, 1 is the rightmost point, and 0.5 is exactly in the middle. |
+| rt            | numeric     | The time in milliseconds, between when the trial began and when the paticipant clicked the continue button. |
+| stimulus          | string     | The stimulus displayed during the trial. |
+
+## Example
+
+```javascript
+var trial = {
+  type: jsPsychHtmlVasResponse,
+  stimulus: 'What is your temperature?',
+  scale_width: 500,
+  labels: ['Maximally<br>cold', 'Maximally<br>hot']
+};
+```

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -1,0 +1,17 @@
+
+var jsPsych = initJsPsych({
+    on_finish: function() {
+        jsPsych.data.displayData('csv');
+    }
+});
+
+var trial = {
+  type: jsPsychHtmlVasResponse,
+  stimulus: 'Some people have the experience of finding themselves in a place and have no idea how they got there.<br>Select the number to show what percentage of the time this happens to you.',
+  ticks: false,
+  scale_width: 500,
+  scale_colour: 'black',
+  labels: ['0%<br>Never', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%<br>Always']
+};
+
+jsPsych.run([trial]);

--- a/packages/plugin-html-vas-response/examples/html-vas-response.js
+++ b/packages/plugin-html-vas-response/examples/html-vas-response.js
@@ -1,0 +1,240 @@
+var jsPsychHtmlVasResponse = (function (jspsych) {
+  "use strict";
+
+  const info = {
+    name: "html-vas-response",
+    parameters: {
+      stimulus: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Stimulus",
+        default: undefined,
+      },
+      labels: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Labels",
+        default: [],
+        array: true,
+      },
+      ticks: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Ticks",
+        default: true,
+      },
+      scale_width: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "VAS width",
+        default: null
+      },
+      scale_height: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "VAS height",
+        default: 40
+      },
+      scale_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Scale colour",
+        default: 'black'
+      },
+      scale_cursor: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Scale cursor",
+        default: 'pointer'
+      },
+      marker_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Marker colour",
+        default: 'rgba(0, 0, 0, 0.5)'
+      },
+      tick_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "tick colour",
+        default: 'black'
+      },
+      prompt: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Prompt",
+        default: null
+      },
+      button_label: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Buton label",
+        default: 'Continue'
+      },
+      required: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Response required",
+        default: false
+      },
+      stimulus_duration: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "Stimulus duration",
+        default: null
+      },
+      trial_duration: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "Trial duration",
+        default: null
+      },
+      response_ends_trial: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Response ends trial",
+        default: true
+      },
+    },
+  };
+  class jsPsychHtmlVasResponsePlugin {
+    constructor(jsPsych) {
+      this.jsPsych = jsPsych;
+    }
+    trial(display_element, trial) {
+      // half of the thumb width value from jspsych.css, used to adjust the label positions
+      var half_thumb_width = 7.5;
+      var html = '<div id="jspsych-html-vas-response-wrapper" style="margin: 100px 0px;">';
+      html += '<div id="jspsych-html-vas-response-stimulus">' + trial.stimulus + "</div>";
+      html +=
+        '<div class="jspsych-html-vas-response-container" style="position:relative; margin: 0 auto 3em auto; ';
+      if (trial.scale_width !== null) {
+        html += "width:" + trial.scale_width + "px;";
+      } else {
+        html += "width:auto;";
+      }
+      html += '">';
+      // Create clickable container for VAS
+      html += '<div id="jspsych-html-vas-response-vas" style="position: relative; left: 0px; top: 0px; height: ' + trial.scale_height + 'px; width: 100%; ' +
+        'cursor: ' + trial.scale_cursor + ';">';
+      // Draw horizontal line in VAS container
+      html += '<div style="position: relative; background: ' + trial.scale_colour + '; width: 100%; height: 2px; top: ' + (trial.scale_height/2 - 1) + 'px"></div>'
+      // Draw vertical line, but hide it at first
+      html += '<div id="jspsych-html-vas-response-vline" style="visibility: hidden; position: absolute; left: 0px; background-color: ' + trial.marker_colour + '; height: ' + trial.scale_height + 'px; width: 2px; top: 0px"></div>'
+      html += "</div>";
+      html += "<div>";
+      for (var j = 0; j < trial.labels.length; j++) {
+        var label_width_perc = 100 / (trial.labels.length - 1);
+        var percent_of_range = j * (100 / (trial.labels.length - 1));
+        var percent_dist_from_center = ((percent_of_range - 50) / 50) * 100;
+        var offset = (percent_dist_from_center * half_thumb_width) / 100;
+        html +=
+          '<div style="border: 1px solid transparent; display: inline-block; position: absolute; ' +
+          "left:calc(" +
+          percent_of_range +
+          "% - (" +
+          label_width_perc +
+          "% / 2) - " +
+          offset +
+          "px); text-align: center; width: " +
+          label_width_perc +
+          '%;">';
+        html += '<span style="text-align: center; font-size: 80%;">' + trial.labels[j] + "</span>";
+        html += "</div>";
+      }
+      html += "</div>";
+      html += "</div>";
+      html += "</div>";
+
+      if (trial.prompt !== null) {
+        html += trial.prompt;
+      }
+
+      // Submit button
+      html +=
+        '<button id="jspsych-html-vas-response-next" class="jspsych-btn" ' +
+        (trial.required ? "disabled" : "") +
+        ">" +
+        trial.button_label +
+        "</button>";
+
+      display_element.innerHTML = html;
+
+      var vas = document.getElementById('jspsych-html-vas-response-vas');
+      // Add minor ticks
+      for (var j = 0; j < trial.labels.length; j++) {
+        var label_width_pct = 100 / (trial.labels.length - 1);
+        var pct_of_range = j * (100 / (trial.labels.length - 1));
+        var mtick = document.createElement('div');
+        mtick.style.position = 'absolute';
+        mtick.style.height = (trial.scale_height/2) + 'px';
+        mtick.style.width = '2px';
+        mtick.style.top = (trial.scale_height/4) + 'px';
+        mtick.style.background = trial.tick_colour;
+        mtick.style.left = (pct_of_range/100 * vas.clientWidth - 1) + 'px';
+        vas.appendChild(mtick);
+      }
+
+      // Function to move vertical tick
+      var pct_tick = null;
+      var vas_enabled = true;
+      vas.onclick = function(e) {
+        if (!vas_enabled) {
+          return;
+        }
+        var vas = document.getElementById('jspsych-html-vas-response-vas');
+        var vas_rect = vas.getBoundingClientRect();
+        if (e.clientX <= vas_rect.right && e.clientX >= vas_rect.left) {
+          var element = vas;
+          var vline = document.getElementById('jspsych-html-vas-response-vline');
+          var cx = Math.round(e.clientX);
+          vline.style.left = (e.clientX - vas_rect.left - 1) + 'px';
+          vline.style.visibility = 'visible';
+          console.log(pct_tick);
+          pct_tick = (e.clientX - vas_rect.left) / vas_rect.width;
+          console.log(pct_tick);
+          vas.appendChild(vline);
+          var continue_button = document.getElementById('jspsych-html-vas-response-next');
+          continue_button.disabled = false;
+        }
+      }
+      
+      var response = {
+        rt: null,
+        response: null,
+      };
+
+      function end_trial() {
+        jsPsych.pluginAPI.clearAllTimeouts();
+
+        // save data
+        var trialdata = {
+          rt: response.rt,
+          stimulus: trial.stimulus,
+          response: response.response,
+        };
+
+        display_element.innerHTML = "";
+
+        // next trial
+        jsPsych.finishTrial(trialdata);
+      };
+
+      var continue_button = document.getElementById('jspsych-html-vas-response-next');
+      continue_button.onclick = function() {
+        // measure response time
+        var endTime = performance.now();
+        response.rt = Math.round(endTime - startTime);
+        response.response = pct_tick;
+        if (trial.response_ends_trial) {
+          end_trial();
+        } else {
+          vas_enabled = false;
+        }
+      }
+
+      // hide stimulus if stimulus_duration is set
+      if (trial.stimulus_duration !== null) {
+        jspsych.pluginAPI.setTimeout(function() {
+          var stim = document.getElementById('jspsych-html-vas-response-stimulus');
+          stim.style.visibility = 'hidden';
+        }, trial.stimulus_duration);
+      }
+
+      // end trial if trial_duration is set
+      if (trial.trial_duration !== null) {
+        jspsych.pluginAPI.setTimeout(end_trial, trial.trial_duration);
+      }
+
+      var startTime = performance.now();
+    }
+  }
+  jsPsychHtmlVasResponsePlugin.info = info;
+
+  return jsPsychHtmlVasResponsePlugin;
+})(jsPsychModule);

--- a/packages/plugin-html-vas-response/examples/index.html
+++ b/packages/plugin-html-vas-response/examples/index.html
@@ -1,0 +1,13 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+	<script src="https://unpkg.com/jspsych@7.0.0"></script>
+	<script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.0.0"></script>
+	<script src="html-vas-response.js"></script>
+	<link href="https://unpkg.com/jspsych@7.0.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+</body>
+<script src='expt.js'></script>
+</html>

--- a/packages/plugin-html-vas-response/index.js
+++ b/packages/plugin-html-vas-response/index.js
@@ -1,0 +1,240 @@
+var jsPsychHtmlVasResponse = (function (jspsych) {
+  "use strict";
+
+  const info = {
+    name: "html-vas-response",
+    parameters: {
+      stimulus: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Stimulus",
+        default: undefined,
+      },
+      labels: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Labels",
+        default: [],
+        array: true,
+      },
+      ticks: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Ticks",
+        default: true,
+      },
+      scale_width: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "VAS width",
+        default: null
+      },
+      scale_height: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "VAS height",
+        default: 40
+      },
+      scale_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Scale colour",
+        default: 'black'
+      },
+      scale_cursor: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Scale cursor",
+        default: 'pointer'
+      },
+      marker_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "Marker colour",
+        default: 'rgba(0, 0, 0, 0.5)'
+      },
+      tick_colour: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: "tick colour",
+        default: 'black'
+      },
+      prompt: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Prompt",
+        default: null
+      },
+      button_label: {
+        type: jspsych.ParameterType.HTML_STRING,
+        pretty_name: "Buton label",
+        default: 'Continue'
+      },
+      required: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Response required",
+        default: false
+      },
+      stimulus_duration: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "Stimulus duration",
+        default: null
+      },
+      trial_duration: {
+        type: jspsych.ParameterType.INT,
+        pretty_name: "Trial duration",
+        default: null
+      },
+      response_ends_trial: {
+        type: jspsych.ParameterType.BOOL,
+        pretty_name: "Response ends trial",
+        default: true
+      },
+    },
+  };
+  class jsPsychHtmlVasResponsePlugin {
+    constructor(jsPsych) {
+      this.jsPsych = jsPsych;
+    }
+    trial(display_element, trial) {
+      // half of the thumb width value from jspsych.css, used to adjust the label positions
+      var half_thumb_width = 7.5;
+      var html = '<div id="jspsych-html-vas-response-wrapper" style="margin: 100px 0px;">';
+      html += '<div id="jspsych-html-vas-response-stimulus">' + trial.stimulus + "</div>";
+      html +=
+        '<div class="jspsych-html-vas-response-container" style="position:relative; margin: 0 auto 3em auto; ';
+      if (trial.scale_width !== null) {
+        html += "width:" + trial.scale_width + "px;";
+      } else {
+        html += "width:auto;";
+      }
+      html += '">';
+      // Create clickable container for VAS
+      html += '<div id="jspsych-html-vas-response-vas" style="position: relative; left: 0px; top: 0px; height: ' + trial.scale_height + 'px; width: 100%; ' +
+        'cursor: ' + trial.scale_cursor + ';">';
+      // Draw horizontal line in VAS container
+      html += '<div style="position: relative; background: ' + trial.scale_colour + '; width: 100%; height: 2px; top: ' + (trial.scale_height/2 - 1) + 'px"></div>'
+      // Draw vertical line, but hide it at first
+      html += '<div id="jspsych-html-vas-response-vline" style="visibility: hidden; position: absolute; left: 0px; background-color: ' + trial.marker_colour + '; height: ' + trial.scale_height + 'px; width: 2px; top: 0px"></div>'
+      html += "</div>";
+      html += "<div>";
+      for (var j = 0; j < trial.labels.length; j++) {
+        var label_width_perc = 100 / (trial.labels.length - 1);
+        var percent_of_range = j * (100 / (trial.labels.length - 1));
+        var percent_dist_from_center = ((percent_of_range - 50) / 50) * 100;
+        var offset = (percent_dist_from_center * half_thumb_width) / 100;
+        html +=
+          '<div style="border: 1px solid transparent; display: inline-block; position: absolute; ' +
+          "left:calc(" +
+          percent_of_range +
+          "% - (" +
+          label_width_perc +
+          "% / 2) - " +
+          offset +
+          "px); text-align: center; width: " +
+          label_width_perc +
+          '%;">';
+        html += '<span style="text-align: center; font-size: 80%;">' + trial.labels[j] + "</span>";
+        html += "</div>";
+      }
+      html += "</div>";
+      html += "</div>";
+      html += "</div>";
+
+      if (trial.prompt !== null) {
+        html += trial.prompt;
+      }
+
+      // Submit button
+      html +=
+        '<button id="jspsych-html-vas-response-next" class="jspsych-btn" ' +
+        (trial.required ? "disabled" : "") +
+        ">" +
+        trial.button_label +
+        "</button>";
+
+      display_element.innerHTML = html;
+
+      var vas = document.getElementById('jspsych-html-vas-response-vas');
+      // Add minor ticks
+      for (var j = 0; j < trial.labels.length; j++) {
+        var label_width_pct = 100 / (trial.labels.length - 1);
+        var pct_of_range = j * (100 / (trial.labels.length - 1));
+        var mtick = document.createElement('div');
+        mtick.style.position = 'absolute';
+        mtick.style.height = (trial.scale_height/2) + 'px';
+        mtick.style.width = '2px';
+        mtick.style.top = (trial.scale_height/4) + 'px';
+        mtick.style.background = trial.tick_colour;
+        mtick.style.left = (pct_of_range/100 * vas.clientWidth - 1) + 'px';
+        vas.appendChild(mtick);
+      }
+
+      // Function to move vertical tick
+      var pct_tick = null;
+      var vas_enabled = true;
+      vas.onclick = function(e) {
+        if (!vas_enabled) {
+          return;
+        }
+        var vas = document.getElementById('jspsych-html-vas-response-vas');
+        var vas_rect = vas.getBoundingClientRect();
+        if (e.clientX <= vas_rect.right && e.clientX >= vas_rect.left) {
+          var element = vas;
+          var vline = document.getElementById('jspsych-html-vas-response-vline');
+          var cx = Math.round(e.clientX);
+          vline.style.left = (e.clientX - vas_rect.left - 1) + 'px';
+          vline.style.visibility = 'visible';
+          console.log(pct_tick);
+          pct_tick = (e.clientX - vas_rect.left) / vas_rect.width;
+          console.log(pct_tick);
+          vas.appendChild(vline);
+          var continue_button = document.getElementById('jspsych-html-vas-response-next');
+          continue_button.disabled = false;
+        }
+      }
+      
+      var response = {
+        rt: null,
+        response: null,
+      };
+
+      function end_trial() {
+        jsPsych.pluginAPI.clearAllTimeouts();
+
+        // save data
+        var trialdata = {
+          rt: response.rt,
+          stimulus: trial.stimulus,
+          response: response.response,
+        };
+
+        display_element.innerHTML = "";
+
+        // next trial
+        jsPsych.finishTrial(trialdata);
+      };
+
+      var continue_button = document.getElementById('jspsych-html-vas-response-next');
+      continue_button.onclick = function() {
+        // measure response time
+        var endTime = performance.now();
+        response.rt = Math.round(endTime - startTime);
+        response.response = pct_tick;
+        if (trial.response_ends_trial) {
+          end_trial();
+        } else {
+          vas_enabled = false;
+        }
+      }
+
+      // hide stimulus if stimulus_duration is set
+      if (trial.stimulus_duration !== null) {
+        jspsych.pluginAPI.setTimeout(function() {
+          var stim = document.getElementById('jspsych-html-vas-response-stimulus');
+          stim.style.visibility = 'hidden';
+        }, trial.stimulus_duration);
+      }
+
+      // end trial if trial_duration is set
+      if (trial.trial_duration !== null) {
+        jspsych.pluginAPI.setTimeout(end_trial, trial.trial_duration);
+      }
+
+      var startTime = performance.now();
+    }
+  }
+  jsPsychHtmlVasResponsePlugin.info = info;
+
+  return jsPsychHtmlVasResponsePlugin;
+})(jsPsychModule);

--- a/packages/plugin-html-vas-response/package.json
+++ b/packages/plugin-html-vas-response/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jspsych-contrib/plugin-html-vas-response",
-  "private": "true",
-  "version": "1.0.0",
+  "private": "false",
+  "version": "0.0.1",
   "description": "",
   "unpkg": "dist/index.browser.min.js",
   "files": [

--- a/packages/plugin-html-vas-response/package.json
+++ b/packages/plugin-html-vas-response/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/jspsych/jspsych-contrib.git",
     "directory": "packages/plugin-html-vas-response"
   },
-  "author": "Josh de Leeuw",
+  "author": "Isaac Kinley",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jspsych/jspsych-contrib/issues"

--- a/packages/plugin-html-vas-response/package.json
+++ b/packages/plugin-html-vas-response/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@jspsych-contrib/plugin-html-vas-response",
+  "private": "true",
+  "version": "1.0.0",
+  "description": "",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "index.js",
+    "dist"
+  ],
+  "scripts": {
+    "build": "babel index.js --config-file @jspsych/config/babel --presets minify --source-maps --out-file dist/index.browser.min.js",
+    "build:watch": "npm run build -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jspsych/jspsych-contrib.git",
+    "directory": "packages/plugin-html-vas-response"
+  },
+  "author": "Josh de Leeuw",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jspsych/jspsych-contrib/issues"
+  },
+  "homepage": "https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-html-vas-response",
+  "devDependencies": {
+    "@jspsych/config": "^1.0.0",
+    "jspsych": "^7.0.0"
+  }
+}


### PR DESCRIPTION
This plugin allows responses using a point-and-click visual analogue scale, as described in [this preprint](https://psyarxiv.com/avj92). An example can be found [here](https://kinleyid.github.io/rsrch/html-vas-response). I added it to the plugins/ folder in a separate branch within my own fork---I hope this is alright. Please let me know if there's anything I should change to make it easier to merge.