### PR TITLE
Adding new functionality to the visual analogue scale

### DIFF
--- a/.changeset/tidy-hairs-behave.md
+++ b/.changeset/tidy-hairs-behave.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-html-vas-response": minor
+---
+
+Add `resp_fcn` parameter and `clicks` data property

--- a/packages/plugin-html-vas-response/README.md
+++ b/packages/plugin-html-vas-response/README.md
@@ -7,7 +7,7 @@ This plugin collects responses to an arbitrary HTML string using a point-and-cli
 ## Loading
 
 ```js
-<script src="https://unpkg.com/@jspsych-contrib/plugin-html-vas-response@1.0.0">
+<script src="https://unpkg.com/@jspsych-contrib/plugin-html-vas-response@1.1.0">
 ```
 
 ## Compatibility

--- a/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
+++ b/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
@@ -14,6 +14,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | ------------------------ | ---------------- | -------------------- | ---------------------------------------- |
 | stimulus                     | HTML string           | `undefined`     | The string to be displayed. |
 | labels                     | array of strings           | `[]`     | Specifies the labels to be displayed, equally spaced along the scale, as in jspsych-html-slider-response. |
+| resp_fcn                     | function           | `null`     | A function called when the participant clicks on the scale. The current location of the participant's response (between 0 and 1) is provided as an input. |
 | ticks                     | Boolean           | `true`     | Specifies whether smaller vertical tick marks should accompany the labels. |
 | scale_width | integer | `null` |  The width of the VAS in pixels. If left null, then the width will be equal to the widest element in the display. |
 | scale_height | integer | 40 | The height of the clickable region around the VAS in pixels. |
@@ -37,6 +38,7 @@ In addition to the [default data collected by all plugins](https://www.jspsych.o
 | response             | numeric      | The value selected, between 0 and 1. 0 is the leftmost point on the scale, 1 is the rightmost point, and 0.5 is exactly in the middle. |
 | rt            | numeric     | The time in milliseconds, between when the trial began and when the paticipant clicked the continue button. |
 | stimulus          | string     | The stimulus displayed during the trial. |
+| clicks          | array of objects     | A record of the participant's clicks on the scale. Each element in the array is an object with properties `time` (the time of the click, in milliseconds since the trial began) and `location` (the location of the click on the VAS, from 0 to 1). |
 
 ## Example
 
@@ -45,6 +47,7 @@ var trial = {
   type: jsPsychHtmlVasResponse,
   stimulus: 'What is your temperature?',
   scale_width: 500,
-  labels: ['Maximally<br>cold', 'Maximally<br>hot']
+  labels: ['Maximally<br>cold', 'Maximally<br>hot'],
+  resp_fcn: function(ppn) {console.log(ppn)}
 };
 ```

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -8,10 +8,16 @@ var jsPsych = initJsPsych({
 var trial = {
   type: jsPsychHtmlVasResponse,
   stimulus: 'Some people have the experience of finding themselves in a place and have no idea how they got there.<br>Select the number to show what percentage of the time this happens to you.',
+  prompt: '<span id="resp-disp"></span><br>',
   ticks: false,
   scale_width: 500,
   scale_colour: 'black',
-  labels: ['0%<br>Never', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%<br>Always']
+  labels: ['0%<br>Never', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%<br>Always'],
+  resp_fcn: function(ppn) {
+    var pct = Math.round(100*ppn);
+    var resp_disp = document.getElementById('resp-disp');
+    resp_disp.textContent = pct + '% of the time';
+  }
 };
 
 jsPsych.run([trial]);

--- a/packages/plugin-html-vas-response/examples/index.html
+++ b/packages/plugin-html-vas-response/examples/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
 	<script src="https://unpkg.com/jspsych@7.0.0"></script>
-	<script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.0.0"></script>
+	<script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
 	<script src="html-vas-response.js"></script>
 	<link href="https://unpkg.com/jspsych@7.0.0/css/jspsych.css" rel="stylesheet" type="text/css" />
 </head>

--- a/packages/plugin-html-vas-response/index.js
+++ b/packages/plugin-html-vas-response/index.js
@@ -15,6 +15,11 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
         default: [],
         array: true,
       },
+      resp_fcn: {
+        type: jspsych.ParameterType.FUNCTION,
+        pretty_name: "Response function",
+        default: null,
+      },
       ticks: {
         type: jspsych.ParameterType.BOOL,
         pretty_name: "Ticks",
@@ -163,7 +168,9 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
       // Function to move vertical tick
       var pct_tick = null;
       var vas_enabled = true;
+      var clicks = [];
       vas.onclick = function(e) {
+        var clickTime = performance.now() - startTime;
         if (!vas_enabled) {
           return;
         }
@@ -175,12 +182,16 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
           var cx = Math.round(e.clientX);
           vline.style.left = (e.clientX - vas_rect.left - 1) + 'px';
           vline.style.visibility = 'visible';
-          console.log(pct_tick);
           pct_tick = (e.clientX - vas_rect.left) / vas_rect.width;
-          console.log(pct_tick);
           vas.appendChild(vline);
           var continue_button = document.getElementById('jspsych-html-vas-response-next');
           continue_button.disabled = false;
+          // record time series of clicks
+          clicks.push({time: clickTime, location: pct_tick});
+          // call
+          if (trial.resp_fcn) {
+            trial.resp_fcn(pct_tick);
+          }
         }
       }
       
@@ -197,6 +208,7 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
           rt: response.rt,
           stimulus: trial.stimulus,
           response: response.response,
+          clicks: clicks
         };
 
         display_element.innerHTML = "";

--- a/packages/plugin-html-vas-response/package.json
+++ b/packages/plugin-html-vas-response/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jspsych-contrib/plugin-html-vas-response",
   "version": "1.0.0",
+  "private": "false",
   "description": "",
   "unpkg": "dist/index.browser.min.js",
   "files": [


### PR DESCRIPTION
I've made it so that a record of the participant's clicks on the scale are recorded (i.e., if the participant first clicks one location then another, both of these are recorded). Also, the new `resp_fcn` parameter allows a function to be called whenever such a click takes place (e.g., to display the numerical value of the participant's current response). These are both demonstrated in the example.