### PR TITLE
Rename data parameter in pipe plugin

### DIFF
--- a/.changeset/orange-birds-yell.md
+++ b/.changeset/orange-birds-yell.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-pipe": minor
+---
+
+Rename data parameter to data_string to avoid conflict with builtin data parameter.

--- a/packages/plugin-pipe/docs/jspsych-pipe.md
+++ b/packages/plugin-pipe/docs/jspsych-pipe.md
@@ -13,7 +13,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | experiment_id | string | undefined | The ID of the experiment. This ID is provided by pipe.jspsych.org. |
 | action | string | undefined | The action to perform. Possible values are `save`, `saveBase64`, and `condition`. |
 | filename | null | undefined | The filename to use when saving data. It should be unique. If the file already exists, no data will be saved. |
-| data | string | null | The string of data to save. If action is `save` then this can be text data in any format (e.g., CSV, JSON, TXT, etc.). If `action` is `saveBase64`, then this should be a base64 encoded string and the `filename` should have the appropriate extension. | 
+| data_string | string | null | The string of data to save. If action is `save` then this can be text data in any format (e.g., CSV, JSON, TXT, etc.). If `action` is `saveBase64`, then this should be a base64 encoded string and the `filename` should have the appropriate extension. | 
 
 
 ## Data Generated
@@ -70,7 +70,7 @@ const save_data = {
   action: "save",
   experiment_id: expID,
   filename: `${subjectID}.csv`,
-  data: ()=>jsPsych.data.get().csv()
+  data_string: ()=>jsPsych.data.get().csv()
 };
 ```
 

--- a/packages/plugin-pipe/examples/jspsych-plugin-pipe-example-1.html
+++ b/packages/plugin-pipe/examples/jspsych-plugin-pipe-example-1.html
@@ -43,7 +43,7 @@
       action: "save",
       experiment_id: expID,
       filename: `${subject_id}.csv`,
-      data: ()=>jsPsych.data.get().csv()
+      data_string: ()=>jsPsych.data.get().csv()
     };
 
     const finished = {

--- a/packages/plugin-pipe/src/index.ts
+++ b/packages/plugin-pipe/src/index.ts
@@ -37,7 +37,7 @@ const info = <const>{
      * The use of a function is necessary to get the updated data at
      * the time of saving.
      */
-    data: {
+    data_string: {
       type: ParameterType.STRING,
       default: null,
     },
@@ -117,10 +117,14 @@ class PipePlugin implements JsPsychPlugin<Info> {
 
     let result: string | number;
     if (trial.action === "save") {
-      result = await PipePlugin.saveData(trial.experiment_id, trial.filename, trial.data);
+      result = await PipePlugin.saveData(trial.experiment_id, trial.filename, trial.data_string);
     }
     if (trial.action === "saveBase64") {
-      result = await PipePlugin.saveBase64Data(trial.experiment_id, trial.filename, trial.data);
+      result = await PipePlugin.saveBase64Data(
+        trial.experiment_id,
+        trial.filename,
+        trial.data_string
+      );
     }
     if (trial.action === "condition") {
       result = await PipePlugin.getCondition(trial.experiment_id);


### PR DESCRIPTION
Using `data` as a parameter name was a dumb move on my part 😁 

This renames to `data_string` to avoid conflict with builtin `data` parameter.