### PR TITLE
fix homepage url in plugin-gamepad's package.json

### DIFF
--- a/.changeset/fifty-keys-live.md
+++ b/.changeset/fifty-keys-live.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/jspsych-gamepad": patch
+---
+
+Fix package.json homepage url

--- a/packages/plugin-gamepad/package.json
+++ b/packages/plugin-gamepad/package.json
@@ -32,7 +32,7 @@
   "bugs": {
     "url": "https://github.com/jspsych/jspsych-contrib/issues"
   },
-  "homepage": "https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-pipe",
+  "homepage": "https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-gamepad",
   "peerDependencies": {
     "jspsych": ">=7.0.0"
   },


### PR DESCRIPTION
The old homepage url pointed to the wrong package.