### PR TITLE
Add html-keyboard-response-raf plugin

### DIFF
--- a/.changeset/large-trains-cheat.md
+++ b/.changeset/large-trains-cheat.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-html-keyboard-response-raf": major
+---
+
+Added html-keyboard-response-raf, a drop in replacement for the html-keyboard-response plugin but using requestAnimationFrame for timing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3099,6 +3099,10 @@
       "resolved": "packages/plugin-html-choice",
       "link": true
     },
+    "node_modules/@jspsych-contrib/plugin-html-keyboard-response-raf": {
+      "resolved": "packages/plugin-html-keyboard-response-raf",
+      "link": true
+    },
     "node_modules/@jspsych-contrib/plugin-html-multi-response": {
       "resolved": "packages/plugin-html-multi-response",
       "link": true
@@ -17633,6 +17637,18 @@
     "packages/plugin-html-choice": {
       "name": "@jspsych-contrib/plugin-html-choice",
       "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@jspsych/config": "^2.0.0",
+        "@jspsych/test-utils": "^1.0.0",
+        "jspsych": "^7.0.0"
+      },
+      "peerDependencies": {
+        "jspsych": ">=7.0.0"
+      }
+    },
+    "packages/plugin-html-keyboard-response-raf": {
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "@jspsych/config": "^2.0.0",

--- a/packages/plugin-html-keyboard-response-raf/README.md
+++ b/packages/plugin-html-keyboard-response-raf/README.md
@@ -1,0 +1,35 @@
+# html-keyboard-response-raf
+
+## Overview
+
+This plugin implements the same functionality as the html-keyboard-response plugin, but uses requestAnimationFrame internally for timing
+
+## Loading
+
+### In browser
+
+```js
+<script src="https://unpkg.com/@jspsych-contrib/plugin-html-keyboard-response-raf@1.0.0">
+```
+
+### Via NPM
+
+```
+npm install @jspsych-contrib/plugin-html-keyboard-response-raf
+```
+
+```js
+import jsPsychHtmlKeyboardResponseRaf from '@jspsych-contrib/plugin-html-keyboard-response-raf';
+```
+
+## Compatibility
+
+jsPsych 7.0.0
+
+## Documentation
+
+See [documentation](https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-html-keyboard-response-raf/docs/html-keyboard-response-raf.md)
+
+## Author / Citation
+
+Josh de Leeuw

--- a/packages/plugin-html-keyboard-response-raf/docs/html-keyboard-response-raf.md
+++ b/packages/plugin-html-keyboard-response-raf/docs/html-keyboard-response-raf.md
@@ -1,0 +1,68 @@
+# html-keyboard-response-raf
+
+This plugin implements the same functionality as the html-keyboard-response plugin, but uses requestAnimationFrame internally for timing
+
+## Parameters
+
+In addition to the [parameters available in all plugins](https://jspsych.org/latest/overview/plugins.md#parameters-available-in-all-plugins), this plugin accepts the following parameters. Parameters with a default value of undefined must be specified. Other parameters can be left unspecified if the default value is acceptable.
+
+| Parameter           | Type             | Default Value      | Description                              |
+| ------------------- | ---------------- | ------------------ | ---------------------------------------- |
+| stimulus            | HTML string      | *undefined*        | The string to be displayed.              |
+| choices             | array of strings | `"ALL_KEYS"` | This array contains the key(s) that the participant is allowed to press in order to respond to the stimulus. Keys should be specified as characters (e.g., `'a'`, `'q'`, `' '`, `'Enter'`, `'ArrowDown'`) - see [this page](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) and [this page (event.key column)](https://www.freecodecamp.org/news/javascript-keycode-list-keypress-event-key-codes/) for more examples. Any key presses that are not listed in the array will be ignored. The default value of `"ALL_KEYS"` means that all keys will be accepted as valid responses. Specifying `"NO_KEYS"` will mean that no responses are allowed. |
+| prompt              | string           | null               | This string can contain HTML markup. Any content here will be displayed below the stimulus. The intention is that it can be used to provide a reminder about the action the participant is supposed to take (e.g., which key to press). |
+| stimulus_duration   | numeric          | null               | How long to display the stimulus in milliseconds. The visibility CSS property of the stimulus will be set to `hidden` after this time has elapsed. If this is null, then the stimulus will remain visible until the trial ends. |
+| trial_duration      | numeric          | null               | How long to wait for the participant to make a response before ending the trial in milliseconds. If the participant fails to make a response before this timer is reached, the participant's response will be recorded as null for the trial and the trial will end. If the value of this parameter is null, then the trial will wait for a response indefinitely. |
+| response_ends_trial | boolean          | true               | If true, then the trial will end whenever the participant makes a response (assuming they make their response before the cutoff specified by the `trial_duration` parameter). If false, then the trial will continue until the value for `trial_duration` is reached. You can set this parameter to `false` to force the participant to view a stimulus for a fixed amount of time, even if they respond before the time is complete. |
+## Data Generated
+
+In addition to the [default data collected by all plugins](https://jspsych.org/latest/overview/plugins.md#data-collected-by-all-plugins), this plugin collects the following data for each trial.
+
+| Name      | Type    | Value                                    |
+| --------- | ------- | ---------------------------------------- |
+| response  | string  | Indicates which key the participant pressed. |
+| rt        | numeric | The response time in milliseconds for the participant to make a response. The time is measured from when the stimulus first appears on the screen until the participant's response. |
+| stimulus  | string  | The HTML content that was displayed on the screen. |
+
+## Install
+
+Using the CDN-hosted JavaScript file:
+
+```js
+<script src="https://unpkg.com/@jspsych-contrib/plugin-html-keyboard-response-raf"></script>
+```
+
+Using the JavaScript file downloaded from a GitHub release dist archive:
+
+```js
+<script src="jspsych/plugin-html-keyboard-response-raf.js"></script>
+```
+
+Using NPM:
+
+```
+npm install @jspsych-contrib/plugin-html-keyboard-response-raf
+```
+
+```js
+import HtmlKeyboardResponseRaf from '@jspsych-contrib/plugin-html-keyboard-response-raf';
+```
+
+## Examples
+
+### Flicker a one-frame stimulus
+
+```javascript
+const trial = {
+  type: jsPsychHtmlKeyboardResponseRaf,
+  stimulus: 'Hello world!',
+  stimulus_duration: 16.6,
+  trial_duration: 50,
+  choices: ['a', 'b', 'c'],
+}
+
+const loop = {
+  timeline: [trial],
+  loop_function: () => true,
+}
+```

--- a/packages/plugin-html-keyboard-response-raf/examples/example1.html
+++ b/packages/plugin-html-keyboard-response-raf/examples/example1.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="https://unpkg.com/jspsych"></script>
+        <script src="../dist/index.browser.js"></script>
+        <link href="https://unpkg.com/jspsych/css/jspsych.css" rel="stylesheet" type="text/css">
+    </head>
+    <body></body>
+    <script>
+        const jsPsych = initJsPsych();
+
+        const trial = {
+            type: jsPsychHtmlKeyboardResponseRaf,
+            stimulus: 'Hello world!',
+            stimulus_duration: 16.6,
+            trial_duration: 50,
+            choices: ['a', 'b', 'c'],
+        }
+
+        const loop = {
+            timeline: [trial],
+            loop_function: () => true,
+        }
+
+        jsPsych.run([loop]);
+    </script>
+</html>

--- a/packages/plugin-html-keyboard-response-raf/jest.config.cjs
+++ b/packages/plugin-html-keyboard-response-raf/jest.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@jspsych/config/jest").makePackageConfig(__dirname);

--- a/packages/plugin-html-keyboard-response-raf/package.json
+++ b/packages/plugin-html-keyboard-response-raf/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@jspsych-contrib/plugin-html-keyboard-response-raf",
+  "version": "0.0.1",
+  "description": "This plugin uses the same functionality as the html-keyboard-response plugin, but uses requestAnimationFrame internally for timing",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "typings": "dist/index.d.ts",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "source": "src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "npm test -- --watch",
+    "tsc": "tsc",
+    "build": "rollup --config",
+    "build:watch": "npm run build -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jspsych/jspsych-contrib.git",
+    "directory": "packages/plugin-html-keyboard-response-raf"
+  },
+  "author": "Josh de Leeuw",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jspsych/jspsych-contrib/issues"
+  },
+  "homepage": "https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-html-keyboard-response-raf",
+  "peerDependencies": {
+    "jspsych": ">=7.0.0"
+  },
+  "devDependencies": {
+    "@jspsych/config": "^2.0.0",
+    "@jspsych/test-utils": "^1.0.0",
+    "jspsych": "^7.0.0"
+  }
+}

--- a/packages/plugin-html-keyboard-response-raf/rollup.config.mjs
+++ b/packages/plugin-html-keyboard-response-raf/rollup.config.mjs
@@ -1,0 +1,3 @@
+import { makeRollupConfig } from "@jspsych/config/rollup";
+
+export default makeRollupConfig("jsPsychHtmlKeyboardResponseRaf");

--- a/packages/plugin-html-keyboard-response-raf/src/index.spec.ts
+++ b/packages/plugin-html-keyboard-response-raf/src/index.spec.ts
@@ -1,0 +1,19 @@
+import { startTimeline } from "@jspsych/test-utils";
+
+import jsPsychHtmlKeyboardResponseRaf from ".";
+
+jest.useFakeTimers();
+
+describe("my plugin", () => {
+  it("should load", async () => {
+    const { expectFinished, getHTML, getData, displayElement, jsPsych } = await startTimeline([
+      {
+        type: jsPsychHtmlKeyboardResponseRaf,
+        parameter_name: 1,
+        parameter_name2: "img.png",
+      },
+    ]);
+
+    await expectFinished();
+  });
+});

--- a/packages/plugin-html-keyboard-response-raf/src/index.spec.ts
+++ b/packages/plugin-html-keyboard-response-raf/src/index.spec.ts
@@ -9,10 +9,12 @@ describe("my plugin", () => {
     const { expectFinished, getHTML, getData, displayElement, jsPsych } = await startTimeline([
       {
         type: jsPsychHtmlKeyboardResponseRaf,
-        parameter_name: 1,
-        parameter_name2: "img.png",
+        stimulus: "Hello world!",
+        trial_duration: 1000,
       },
     ]);
+
+    jest.runAllTimers();
 
     await expectFinished();
   });

--- a/packages/plugin-html-keyboard-response-raf/src/index.ts
+++ b/packages/plugin-html-keyboard-response-raf/src/index.ts
@@ -1,0 +1,228 @@
+import { JsPsych, JsPsychPlugin, ParameterType, TrialType } from "jspsych";
+
+const info = <const>{
+  name: "html-keyboard-response-raf",
+  parameters: {
+    /**
+     * The HTML string to be displayed.
+     */
+    stimulus: {
+      type: ParameterType.HTML_STRING,
+      pretty_name: "Stimulus",
+      default: undefined,
+    },
+    /**
+     * Array containing the key(s) the subject is allowed to press to respond to the stimulus.
+     */
+    choices: {
+      type: ParameterType.KEYS,
+      pretty_name: "Choices",
+      default: "ALL_KEYS",
+    },
+    /**
+     * Any content here will be displayed below the stimulus.
+     */
+    prompt: {
+      type: ParameterType.HTML_STRING,
+      pretty_name: "Prompt",
+      default: null,
+    },
+    /**
+     * How long to show the stimulus.
+     */
+    stimulus_duration: {
+      type: ParameterType.INT,
+      pretty_name: "Stimulus duration",
+      default: null,
+    },
+    /**
+     * How long to show trial before it ends.
+     */
+    trial_duration: {
+      type: ParameterType.INT,
+      pretty_name: "Trial duration",
+      default: null,
+    },
+    /**
+     * If true, trial will end when subject makes a response.
+     */
+    response_ends_trial: {
+      type: ParameterType.BOOL,
+      pretty_name: "Response ends trial",
+      default: true,
+    },
+  },
+};
+
+type Info = typeof info;
+
+/**
+ * **html-keyboard-response-raf**
+ *
+ * jsPsych plugin for displaying a stimulus and getting a keyboard response, using requestAnimationFrame for timing.
+ *
+ * @author Josh de Leeuw
+ */
+class HtmlKeyboardResponseRafPlugin implements JsPsychPlugin<Info> {
+  static info = info;
+
+  private keyboardListener;
+  private hideStimulusTime: number = Infinity;
+  private endTrialTime: number = Infinity;
+  private stimulusIsHidden = false;
+  private currAnimationFrameHandler: number;
+
+  constructor(private jsPsych: JsPsych) {}
+
+  trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    var new_html = '<div id="jspsych-html-keyboard-response-stimulus">' + trial.stimulus + "</div>";
+
+    // add prompt
+    if (trial.prompt !== null) {
+      new_html += trial.prompt;
+    }
+
+    // store response
+    var response = {
+      rt: null,
+      key: null,
+    };
+
+    // draw
+    this.currAnimationFrameHandler = requestAnimationFrame(() => {
+      const initialDisplayTime = performance.now();
+
+      display_element.innerHTML = new_html;
+
+      // start the response listener
+      if (trial.choices != "NO_KEYS") {
+        this.keyboardListener = this.jsPsych.pluginAPI.getKeyboardResponse({
+          callback_function: after_response,
+          valid_responses: trial.choices,
+          rt_method: "performance",
+          persist: false,
+          allow_held_key: false,
+        });
+      }
+
+      // hide stimulus if stimulus_duration is set
+      if (trial.stimulus_duration !== null) {
+        this.hideStimulusTime = initialDisplayTime + trial.stimulus_duration;
+      }
+
+      // end trial if trial_duration is set
+      if (trial.trial_duration !== null) {
+        this.endTrialTime = initialDisplayTime + trial.trial_duration;
+      }
+
+      this.currAnimationFrameHandler = requestAnimationFrame(checkForEnd);
+    });
+
+    const checkForEnd = () => {
+      const currTime = performance.now();
+      if (currTime >= this.hideStimulusTime && !this.stimulusIsHidden) {
+        this.stimulusIsHidden = true;
+        display_element.querySelector<HTMLElement>(
+          "#jspsych-html-keyboard-response-stimulus"
+        ).style.visibility = "hidden";
+        console.log(currTime - this.hideStimulusTime);
+      }
+      if (currTime >= this.endTrialTime) {
+        console.log(currTime - this.endTrialTime);
+        end_trial();
+      } else {
+        this.currAnimationFrameHandler = requestAnimationFrame(checkForEnd);
+      }
+    };
+
+    // function to end trial when it is time
+    const end_trial = () => {
+      cancelAnimationFrame(this.currAnimationFrameHandler);
+
+      // kill keyboard listeners
+      if (typeof this.keyboardListener !== "undefined") {
+        this.jsPsych.pluginAPI.cancelKeyboardResponse(this.keyboardListener);
+      }
+
+      // gather the data to store for the trial
+      var trial_data = {
+        rt: response.rt,
+        stimulus: trial.stimulus,
+        response: response.key,
+      };
+
+      // clear the display
+      display_element.innerHTML = "";
+
+      // move on to the next trial
+      this.jsPsych.finishTrial(trial_data);
+    };
+
+    // function to handle responses by the subject
+    const after_response = (info) => {
+      // after a valid response, the stimulus will have the CSS class 'responded'
+      // which can be used to provide visual feedback that a response was recorded
+      display_element.querySelector("#jspsych-html-keyboard-response-stimulus").className +=
+        " responded";
+
+      // only record the first response
+      if (response.key == null) {
+        response = info;
+      }
+
+      if (trial.response_ends_trial) {
+        end_trial();
+      }
+    };
+  }
+
+  simulate(
+    trial: TrialType<Info>,
+    simulation_mode,
+    simulation_options: any,
+    load_callback: () => void
+  ) {
+    if (simulation_mode == "data-only") {
+      load_callback();
+      this.simulate_data_only(trial, simulation_options);
+    }
+    if (simulation_mode == "visual") {
+      this.simulate_visual(trial, simulation_options, load_callback);
+    }
+  }
+
+  private create_simulation_data(trial: TrialType<Info>, simulation_options) {
+    const default_data = {
+      stimulus: trial.stimulus,
+      rt: this.jsPsych.randomization.sampleExGaussian(500, 50, 1 / 150, true),
+      response: this.jsPsych.pluginAPI.getValidKey(trial.choices),
+    };
+
+    const data = this.jsPsych.pluginAPI.mergeSimulationData(default_data, simulation_options);
+
+    this.jsPsych.pluginAPI.ensureSimulationDataConsistency(trial, data);
+
+    return data;
+  }
+
+  private simulate_data_only(trial: TrialType<Info>, simulation_options) {
+    const data = this.create_simulation_data(trial, simulation_options);
+
+    this.jsPsych.finishTrial(data);
+  }
+
+  private simulate_visual(trial: TrialType<Info>, simulation_options, load_callback: () => void) {
+    const data = this.create_simulation_data(trial, simulation_options);
+
+    const display_element = this.jsPsych.getDisplayElement();
+
+    this.trial(display_element, trial);
+    load_callback();
+
+    if (data.rt !== null) {
+      this.jsPsych.pluginAPI.pressKey(data.response, data.rt);
+    }
+  }
+}
+
+export default HtmlKeyboardResponseRafPlugin;

--- a/packages/plugin-html-keyboard-response-raf/tsconfig.json
+++ b/packages/plugin-html-keyboard-response-raf/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@jspsych/config/tsconfig.contrib.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This plugin is a drop-in replacement for the html-keyboard-response plugin, but it uses `requestAnimationFrame` for display timing.