### PR TITLE
docs-add-paper-reference-to-extension-touchscreen-buttons

### DIFF
--- a/packages/extension-touchscreen-buttons/readme.md
+++ b/packages/extension-touchscreen-buttons/readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This extension displays touch buttons allows the subject to respond to stimuli via touchscreen on mobile devices. The touch button send key press events so that all jsPsych plugins that use keyboard input are compatible.
+This extension displays touch buttons that allow the subject to respond to stimuli via a touchscreen on mobile devices. The touch button sends key press events so that all jsPsych plugins that use keyboard input are compatible.
 
 
 ## Loading
@@ -24,3 +24,8 @@ See [documentation](docs/jspsych-touchscreen-buttons.md)
 ## Author / Citation
 
 Created by [Younes Strittmatter](https://github.com/younesStrittmatter).
+
+We would appreciate it if you cited this paper when you use the touchscreen-buttons extension plugin.
+
+Strittmatter, Y., Spitzer, M., Ging-Jehli, N., & Musslick, S. (2023, November 7). A jsPsych Touchscreen Extension for Behavioral Research on Touch-Enabled Interface. https://doi.org/10.31234/osf.io/akzwj
+

--- a/packages/extension-touchscreen-buttons/readme.md
+++ b/packages/extension-touchscreen-buttons/readme.md
@@ -25,7 +25,7 @@ See [documentation](docs/jspsych-touchscreen-buttons.md)
 
 Created by [Younes Strittmatter](https://github.com/younesStrittmatter).
 
-We would appreciate it if you cited this paper when you use the touchscreen-buttons extension plugin.
+We would appreciate it if you cited this paper when you use the touchscreen-buttons extension.
 
 Strittmatter, Y., Spitzer, M., Ging-Jehli, N., & Musslick, S. (2023, November 7). A jsPsych Touchscreen Extension for Behavioral Research on Touch-Enabled Interface. https://doi.org/10.31234/osf.io/akzwj
 


### PR DESCRIPTION
add a reference to preprint and correct some spelling errors in the readme of the touchscreen-buttons extension