### PR TITLE
cli tool bug fix

### DIFF
--- a/templates/cli/src/index.js
+++ b/templates/cli/src/index.js
@@ -100,7 +100,7 @@ inquirer
     gulp.task("renameDocsTemplate", function () {
       return gulp
         .src(`${repoRoot}/packages/${destPath}/docs/docs-template.md`)
-        .pipe(rename(`${answers.name}.md`))
+        .pipe(rename(`jspsych-${answers.name}.md`))
         .pipe(gulp.dest(`${repoRoot}/packages/${destPath}/docs`))
         .on("end", function () {
           deleteSync(`${repoRoot}/packages/${destPath}/docs/docs-template.md`);


### PR DESCRIPTION
I spotted this bug in the cli tool for creating new plugins and extensions:

The line in the template `README.md` files looks like this:

```
See [documentation](https://github.com/jspsych/jspsych-contrib/blob/main/packages/{full-name}/docs/jspsych-{name}.md)
```

It prefixes a "jspsych-" for the documentation file.

However, in the cli source code, it looks like this:

```javascript
    gulp.task("renameDocsTemplate", function () {
      return gulp
        .src(`${repoRoot}/packages/${destPath}/docs/docs-template.md`)
        .pipe(rename(`${answers.name}.md`))
        .pipe(gulp.dest(`${repoRoot}/packages/${destPath}/docs`))
        .on("end", function () {
          deleteSync(`${repoRoot}/packages/${destPath}/docs/docs-template.md`);
        });
    });
```

The renaming does not prefix a "jspsych-", which leads to a discrepancy between the url and the actual doc name. This PR fixes that issue.