### PR TITLE
Ability to display wait message above loading graphics during upload

### DIFF
--- a/.changeset/sixty-dots-ring.md
+++ b/.changeset/sixty-dots-ring.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-pipe": minor
+---
+
+Added ability to display wait message above loading graphics during upload.

--- a/packages/plugin-pipe/docs/jspsych-pipe.md
+++ b/packages/plugin-pipe/docs/jspsych-pipe.md
@@ -14,6 +14,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | action | string | undefined | The action to perform. Possible values are `save`, `saveBase64`, and `condition`. |
 | filename | null | undefined | The filename to use when saving data. It should be unique. If the file already exists, no data will be saved. |
 | data_string | string | null | The string of data to save. If action is `save` then this can be text data in any format (e.g., CSV, JSON, TXT, etc.). If `action` is `saveBase64`, then this should be a base64 encoded string and the `filename` should have the appropriate extension. | 
+| wait_message | HTML_string | `<p>Saving data. Please do not close this page.</p>` | An HTML message to be displayed above the loading graphics in the experiment during data upload. | 
 
 
 ## Data Generated

--- a/packages/plugin-pipe/src/index.ts
+++ b/packages/plugin-pipe/src/index.ts
@@ -41,6 +41,13 @@ const info = <const>{
       type: ParameterType.STRING,
       default: null,
     },
+    /**
+     * An html message to be displayed above the loading graphics in the experiment during data save.
+     */
+    wait_message: {
+      type: ParameterType.HTML_STRING,
+      default: `<p>Saving data. Please do not close this page.</p>`,
+    },
   },
 };
 
@@ -70,11 +77,6 @@ class PipePlugin implements JsPsychPlugin<Info> {
     const progressCSS = `
       .spinner {
         animation: rotate 2s linear infinite;
-        z-index: 2;
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        margin: -25px 0 0 -25px;
         width: 50px;
         height: 50px;
       }
@@ -108,7 +110,8 @@ class PipePlugin implements JsPsychPlugin<Info> {
     `;
 
     const progressHTML = `
-      <style>${progressCSS}</style>
+    <style>${progressCSS}</style>
+      ${trial.wait_message}
       <svg class="spinner" viewBox="0 0 50 50">
         <circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="5"></circle>
       </svg>`;

--- a/packages/plugin-pipe/src/index.ts
+++ b/packages/plugin-pipe/src/index.ts
@@ -42,7 +42,7 @@ const info = <const>{
       default: null,
     },
     /**
-     * An html message to be displayed above the loading graphics in the experiment during data save.
+     * An HTML message to be displayed above the loading graphics in the experiment during data upload.
      */
     wait_message: {
       type: ParameterType.HTML_STRING,


### PR DESCRIPTION
This allows the users of the pipe plugin to optionally pass a message they want to be displayed above the loading spinner graphic that occurs during the data upload process. This message is passed as a parameter called `wait_message` when creating the data pipe trial.

The parameter expects an HTML string so that users can change formatting and content. There is also a default `wait_message` that is displayed now during data upload. Additionally, the CSS for the spinner graphics was trimmed.