### PR TITLE
Fixed templates to match v8 version and data parameter standards for …

### DIFF
--- a/templates/extension-template-js/index.js
+++ b/templates/extension-template-js/index.js
@@ -28,8 +28,8 @@ var _globalName_ = (function (jspsych) {
 
     on_finish(params) {
       return {
-        data_name: 99, // Make sure this type and name matches data_name
-        data_name2: "hello world!", // Make this this type and name matches data_name2
+        data1: 99, // Make sure this type and name matches data1
+        data2: "hello world!", // Make this this type and name matches data2
       };
     }
   }
@@ -37,12 +37,12 @@ var _globalName_ = (function (jspsych) {
     name: "{name}",
     version: version,
     data: {
-      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
-      data_name: {
+      /** Provide a clear description of the data1 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data1: {
         type: ParameterType.INT,
       },
-      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
-      data_name2: {
+      /** Provide a clear description of the data2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data2: {
         type: ParameterType.STRING,
       },
     },

--- a/templates/extension-template-js/index.js
+++ b/templates/extension-template-js/index.js
@@ -1,5 +1,3 @@
-import { version } from "./package.json";
-
 var _globalName_ = (function (jspsych) {
   "use strict";
 
@@ -28,14 +26,14 @@ var _globalName_ = (function (jspsych) {
 
     on_finish(params) {
       return {
-        data1: 99, // Make sure this type and name matches data1
-        data2: "hello world!", // Make this this type and name matches data2
+        data1: 99, // Make sure this type and name matches the information for data1 in the data object contained within the info const.
+        data2: "hello world!", // Make sure this type and name matches the information for data2 in the data object contained within the info const.
       };
     }
   }
   ExtensionNameExtension.info = {
     name: "{name}",
-    version: version,
+    version: "1.0.0", // When working in a Javascript environment with no build, you will need to manually put set the version information. This is used for metadata purposes and publishing.
     data: {
       /** Provide a clear description of the data1 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
       data1: {

--- a/templates/extension-template-js/index.js
+++ b/templates/extension-template-js/index.js
@@ -1,3 +1,5 @@
+import { version } from "./package.json";
+
 var _globalName_ = (function (jspsych) {
   "use strict";
 
@@ -26,12 +28,24 @@ var _globalName_ = (function (jspsych) {
 
     on_finish(params) {
       return {
-        data_property: "data_value",
+        data_name: 99, // Make sure this type and name matches data_name
+        data_name2: "hello world!", // Make this this type and name matches data_name2
       };
     }
   }
   ExtensionNameExtension.info = {
     name: "{name}",
+    version: version,
+    data: {
+      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
+      data_name: {
+        type: ParameterType.INT,
+      },
+      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
+      data_name2: {
+        type: ParameterType.STRING,
+      },
+    },
   };
 
   return ExtensionNameExtension;

--- a/templates/extension-template-ts/src/index.ts
+++ b/templates/extension-template-ts/src/index.ts
@@ -48,8 +48,8 @@ class ExtensionNameExtension implements JsPsychExtension {
 
   on_finish = ({}: OnFinishParameters): { [key: string]: any } => {
     return {
-      data1: 99, // Make sure this type and name matches data1
-      data2: "hello world!", // Make this this type and name matches data2
+      data1: 99, // Make sure this type and name matches the information for data1 in the data object contained within the info const.
+      data2: "hello world!", // Make sure this type and name matches the information for data2 in the data object contained within the info const.
     };
   };
 }

--- a/templates/extension-template-ts/src/index.ts
+++ b/templates/extension-template-ts/src/index.ts
@@ -1,4 +1,6 @@
-import { JsPsych, JsPsychExtension, JsPsychExtensionInfo } from "jspsych";
+import { JsPsych, JsPsychExtension, JsPsychExtensionInfo, ParameterType } from "jspsych";
+
+import { version } from "../package.json";
 
 interface InitializeParameters {}
 
@@ -19,6 +21,17 @@ interface OnFinishParameters {}
 class ExtensionNameExtension implements JsPsychExtension {
   static info: JsPsychExtensionInfo = {
     name: "{name}",
+    version: version,
+    data: {
+      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
+      data_name: {
+        type: ParameterType.INT,
+      },
+      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
+      data_name2: {
+        type: ParameterType.STRING,
+      },
+    },
   };
 
   constructor(private jsPsych: JsPsych) {}
@@ -35,7 +48,8 @@ class ExtensionNameExtension implements JsPsychExtension {
 
   on_finish = ({}: OnFinishParameters): { [key: string]: any } => {
     return {
-      data_property: "data_value",
+      data_name: 99, // Make sure this type and name matches data_name
+      data_name2: "hello world!", // Make this this type and name matches data_name2
     };
   };
 }

--- a/templates/extension-template-ts/src/index.ts
+++ b/templates/extension-template-ts/src/index.ts
@@ -23,12 +23,12 @@ class ExtensionNameExtension implements JsPsychExtension {
     name: "{name}",
     version: version,
     data: {
-      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
-      data_name: {
+      /** Provide a clear description of the data1 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data1: {
         type: ParameterType.INT,
       },
-      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
-      data_name2: {
+      /** Provide a clear description of the data2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data2: {
         type: ParameterType.STRING,
       },
     },
@@ -48,8 +48,8 @@ class ExtensionNameExtension implements JsPsychExtension {
 
   on_finish = ({}: OnFinishParameters): { [key: string]: any } => {
     return {
-      data_name: 99, // Make sure this type and name matches data_name
-      data_name2: "hello world!", // Make this this type and name matches data_name2
+      data1: 99, // Make sure this type and name matches data1
+      data2: "hello world!", // Make this this type and name matches data2
     };
   };
 }

--- a/templates/extension-template-ts/tsconfig.json
+++ b/templates/extension-template-ts/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@jspsych/config/tsconfig.contrib.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/templates/plugin-template-js/index.js
+++ b/templates/plugin-template-js/index.js
@@ -1,11 +1,9 @@
-import { version } from "./package.json";
-
 var _globalName_ = (function (jspsych) {
   "use strict";
 
   const info = {
     name: "{name}",
-    version: version,
+    version: "1.0.0", // When working in a Javascript environment with no build, you will need to manually put set the version information. This is used for metadata purposes and publishing.
     parameters: {
       /** Provide a clear description of the parameter_name that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
       parameter_name: {
@@ -45,8 +43,8 @@ var _globalName_ = (function (jspsych) {
     trial(display_element, trial) {
       // data saving
       var trial_data = {
-        data1: 99, // Make sure this type and name matches data1
-        data2: "hello world!", // Make this this type and name matches data2
+        data1: 99, // Make sure this type and name matches the information for data1 in the data object contained within the info const.
+        data2: "hello world!", // Make sure this type and name matches the information for data2 in the data object contained within the info const.
       };
       // end trial
       this.jsPsych.finishTrial(trial_data);

--- a/templates/plugin-template-js/index.js
+++ b/templates/plugin-template-js/index.js
@@ -1,16 +1,31 @@
+import { version } from "./package.json";
+
 var _globalName_ = (function (jspsych) {
   "use strict";
 
   const info = {
     name: "{name}",
+    version: version,
     parameters: {
+      /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
       parameter_name: {
         type: jspsych.ParameterType.INT,
         default: undefined,
       },
+      /** This comment will be scraped as docs for parameter_name2 when running generating the JsPsych docs.  */
       parameter_name2: {
         type: jspsych.ParameterType.IMAGE,
         default: undefined,
+      },
+    },
+    data: {
+      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
+      data_name: {
+        type: jspsych.ParameterType.INT,
+      },
+      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
+      data_name2: {
+        type: jspsych.ParameterType.STRING,
       },
     },
   };
@@ -30,7 +45,8 @@ var _globalName_ = (function (jspsych) {
     trial(display_element, trial) {
       // data saving
       var trial_data = {
-        parameter_name: "parameter value",
+        data_name: 99, // Make sure this type and name matches data_name
+        data_name2: "hello world!", // Make this this type and name matches data_name2
       };
       // end trial
       this.jsPsych.finishTrial(trial_data);

--- a/templates/plugin-template-js/index.js
+++ b/templates/plugin-template-js/index.js
@@ -7,25 +7,25 @@ var _globalName_ = (function (jspsych) {
     name: "{name}",
     version: version,
     parameters: {
-      /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
+      /** Provide a clear description of the parameter_name that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
       parameter_name: {
         type: jspsych.ParameterType.INT,
         default: undefined,
       },
-      /** This comment will be scraped as docs for parameter_name2 when running generating the JsPsych docs.  */
+      /** Provide a clear description of the parameter_name2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
       parameter_name2: {
         type: jspsych.ParameterType.IMAGE,
         default: undefined,
       },
     },
     data: {
-      /** This comment will be scraped as metadata for data_name when running the metadata module.  */
-      data_name: {
-        type: jspsych.ParameterType.INT,
+      /** Provide a clear description of the data1 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data1: {
+        type: ParameterType.INT,
       },
-      /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
-      data_name2: {
-        type: jspsych.ParameterType.STRING,
+      /** Provide a clear description of the data2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+      data2: {
+        type: ParameterType.STRING,
       },
     },
   };
@@ -45,8 +45,8 @@ var _globalName_ = (function (jspsych) {
     trial(display_element, trial) {
       // data saving
       var trial_data = {
-        data_name: 99, // Make sure this type and name matches data_name
-        data_name2: "hello world!", // Make this this type and name matches data_name2
+        data1: 99, // Make sure this type and name matches data1
+        data2: "hello world!", // Make this this type and name matches data2
       };
       // end trial
       this.jsPsych.finishTrial(trial_data);

--- a/templates/plugin-template-ts/src/index.ts
+++ b/templates/plugin-template-ts/src/index.ts
@@ -47,8 +47,8 @@ class PluginNamePlugin implements JsPsychPlugin<Info> {
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     // data saving
     var trial_data = {
-      data1: 99, // Make sure this type and name matches data1
-      data2: "hello world!", // Make this this type and name matches data2
+      data1: 99, // Make sure this type and name matches the information for data1 in the data object contained within the info const.
+      data2: "hello world!", // Make sure this type and name matches the information for data2 in the data object contained within the info const.
     };
 
     // end trial

--- a/templates/plugin-template-ts/src/index.ts
+++ b/templates/plugin-template-ts/src/index.ts
@@ -1,15 +1,30 @@
 import { JsPsych, JsPsychPlugin, ParameterType, TrialType } from "jspsych";
 
+import { version } from "../package.json";
+
 const info = <const>{
   name: "{name}",
+  version: version,
   parameters: {
+    /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
     parameter_name: {
       type: ParameterType.INT, // BOOL, STRING, INT, FLOAT, FUNCTION, KEY, KEYS, SELECT, HTML_STRING, IMAGE, AUDIO, VIDEO, OBJECT, COMPLEX
       default: undefined,
     },
+    /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
     parameter_name2: {
       type: ParameterType.IMAGE,
       default: undefined,
+    },
+  },
+  data: {
+    /** This comment will be scraped as metadata for data_name when running the metadata module.  */
+    data_name: {
+      type: ParameterType.INT,
+    },
+    /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
+    data_name2: {
+      type: ParameterType.STRING,
     },
   },
 };
@@ -32,7 +47,8 @@ class PluginNamePlugin implements JsPsychPlugin<Info> {
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     // data saving
     var trial_data = {
-      parameter_name: "parameter value",
+      data_name: 99, // Make sure this type and name matches data_name
+      data_name2: "hello world!", // Make this this type and name matches data_name2
     };
 
     // end trial

--- a/templates/plugin-template-ts/src/index.ts
+++ b/templates/plugin-template-ts/src/index.ts
@@ -6,24 +6,24 @@ const info = <const>{
   name: "{name}",
   version: version,
   parameters: {
-    /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
+    /** Provide a clear description of the parameter_name that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
     parameter_name: {
       type: ParameterType.INT, // BOOL, STRING, INT, FLOAT, FUNCTION, KEY, KEYS, SELECT, HTML_STRING, IMAGE, AUDIO, VIDEO, OBJECT, COMPLEX
       default: undefined,
     },
-    /** This comment will be scraped as docs for parameter_name when running generating the JsPsych docs.  */
+    /** Provide a clear description of the parameter_name2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
     parameter_name2: {
       type: ParameterType.IMAGE,
       default: undefined,
     },
   },
   data: {
-    /** This comment will be scraped as metadata for data_name when running the metadata module.  */
-    data_name: {
+    /** Provide a clear description of the data1 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+    data1: {
       type: ParameterType.INT,
     },
-    /** This comment will be scraped as metadata for data_name2 when running the metadata module.  */
-    data_name2: {
+    /** Provide a clear description of the data2 that could be used as documentation. We will eventually use these comments to automatically build documentation and produce metadata. */
+    data2: {
       type: ParameterType.STRING,
     },
   },
@@ -47,8 +47,8 @@ class PluginNamePlugin implements JsPsychPlugin<Info> {
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     // data saving
     var trial_data = {
-      data_name: 99, // Make sure this type and name matches data_name
-      data_name2: "hello world!", // Make this this type and name matches data_name2
+      data1: 99, // Make sure this type and name matches data1
+      data2: "hello world!", // Make this this type and name matches data2
     };
 
     // end trial

--- a/templates/plugin-template-ts/tsconfig.json
+++ b/templates/plugin-template-ts/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@jspsych/config/tsconfig.contrib.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
I updated plugin and extension templates to match v8 updates. Added version and data fields to all templates and imported from their respective package.json files. Additional left comments describing how data parameters should match trial_data. Added comments to parameters indicating that in updates the javadoc comments will be scraped to create documentation. Changed configuration for extensions by including fields and ts.config.files to allow json. 

I tested the CLI tool correctly used the four new templates with the updated information. 