### PR TITLE
Add function for flipping coherent dots in a trial

### DIFF
--- a/.changeset/odd-laws-sleep.md
+++ b/.changeset/odd-laws-sleep.md
@@ -1,5 +1,5 @@
 ---
-"@jspsych-contrib/plugin-rdk": patch
+"@jspsych-contrib/plugin-rdk": minor
 ---
 
 If you want coherent dots to change their directions during a trial, you can set `flip_timestamps` and flip their directions as much as you want.

--- a/.changeset/odd-laws-sleep.md
+++ b/.changeset/odd-laws-sleep.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-rdk": patch
+---
+
+If you want coherent dots to change their directions during a trial, you can set `flip_timestamps` and flip their directions as much as you want.

--- a/packages/plugin-rdk/docs/jspsych-rdk.md
+++ b/packages/plugin-rdk/docs/jspsych-rdk.md
@@ -18,6 +18,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | choices                  | array of strings | jsPsych.ALL_KEYS     | The valid keys that the subject can press as a response. Must be an array of strings. If left unspecified, any key is a valid key. |
 | correct_choice           | array of strings  | *undefined*          | Array containing the key(s) that are considered the correct response for that particular trial. This needs to be linked with the `coherent_direction` parameter (see Examples section below for an illustration). This is used to determine whether the subject chose the correct response. The boolean indicating whether or not the subject chose the correct response is returned in the `correct` key of the data object. |
 | trial_duration           | numeric          | 500                  | The amount of time that the stimulus is displayed on the screen in ms. If -1, the stimulus will be displayed until the subject keys in a valid response. (`choices` parameter must contain valid keys or else the stimuli will run indefinitely). |
+| flip_timestamps          | array of numerics | []                  | Timestamps to flip the direction of coherent dots. |
 | response_ends_trial      | boolean          | true                 | If `true`, then the subject's response will end the trial. If `false`, the stimuli will be presented for the full `trial_duration` (the response will be recorded as long as the subject responds within the trial duration). |
 | number_of_apertures      | numeric          | 1                    | The number of apertures or RDKs on the screen. If set to more than one, remember to set the location (i.e., aperture_center_x and aperture_center_y) parameters to separate them. <br>In addition, each aperture can be customized individually by passing in an array of values as the parameter (see example below). If a single value (not an array) is passed as the parameter, then all apertures will have the same parameter. |
 | number_of_dots           | numeric          | 300                  | Number of dots per set. Equivalent to number of dots per frame. |
@@ -82,19 +83,19 @@ In addition to the [default data collected by all plugins](https://www.jspsych.o
 
 ```javascript
 var trial = {
-    type: jsPsychRdk, 
+    type: jsPsychRdk,
     coherent_direction: 0,
     correct_choice: ["p"]
 };
-```    
+```
 
 See `examples/example2.html` for a demo.
-  
+
 ### "Displaying a trial with 2 choices and 1 correct choice"
 
 ```javascript
 var trial = {
-    type: jsPsychRdk, 
+    type: jsPsychRdk,
     post_trial_gap: 0,
     number_of_dots: 200,
     RDK_type: 3,
@@ -103,7 +104,7 @@ var trial = {
     coherent_direction: 180,
     trial_duration: 1000
 };
-``` 
+```
 
 See `examples/example3.html` for a demo.
 
@@ -112,7 +113,7 @@ See `examples/example3.html` for a demo.
 
 ```javascript
 var trial = {
-    type: jsPsychRdk, 
+    type: jsPsychRdk,
     number_of_apertures: 3, //This needs to be set if more than one aperture
     trial_duration: 10000,
     correct_choice: ["a"],
@@ -121,7 +122,7 @@ var trial = {
     number_of_dots: [50, 200, 100], //Different parameter for each aperture. Array length must equal number_of_apertures
     aperture_center_x: [(window.innerWidth/2)-300,window.innerWidth/2,(window.innerWidth/2)+300] //Separate the apertures on the screen (window.innerWidth/2 is the middle of the screen)
 };
-``` 
+```
 
 See `examples/example4.html` for a demo.
 

--- a/packages/plugin-rdk/examples/example1.html
+++ b/packages/plugin-rdk/examples/example1.html
@@ -14,13 +14,13 @@
       }
     });
 
-		/* 
-		We would appreciate it if you cited this paper when you use the RDK: 
+		/*
+		We would appreciate it if you cited this paper when you use the RDK:
 		Rajananda, S., Lau, H. & Odegaard, B., (2018). A Random-Dot Kinematogram for Web-Based Vision Research. Journal of Open Research Software. 6(1), p.6. DOI: [http://doi.org/10.5334/jors.194]
 		*/
 
 		//---------Create trials---------
-		
+
 		// Create an array of 2 different trials (different conditions)
 		var RDK_trials = [
 			{ // Condition 1
@@ -29,11 +29,12 @@
 			},
 			{ // Condition 2
 				correct_choice: ['l'], // The correct answer for Condition 2
-				coherent_direction: 0 // The coherent direction for Condition 2 (dots move right)
+				coherent_direction: 0, // The coherent direction for Condition 2 (dots move right)
+				flip_timestamps: [300, 600],
 			},
 		];
-		
-		// The test block where all the trials are nested. The properties here will trickle down to all trials in the timeline unless they have their own properties defined   
+
+		// The test block where all the trials are nested. The properties here will trickle down to all trials in the timeline unless they have their own properties defined
 		var test_block = {
 			type: jsPsychRdk,
 			post_trial_gap: 500, // The Inter Trial Interval. You can either have no ITI, or have an ITI but change the display element to be the same color as the stimuli background to prevent flashing between trials
@@ -45,9 +46,9 @@
 			background_color: "white",
 			dot_color: "black"
 		};
-		
+
 		//---------Run the experiment---------
-		
+
 		jsPsych.run([test_block]);
 
 	</script>

--- a/packages/plugin-rdk/src/index.ts
+++ b/packages/plugin-rdk/src/index.ts
@@ -21,6 +21,13 @@ const info = <const>{
       pretty_name: "Trial duration",
       default: 500,
     },
+    /** Flip timestamp array of coherent dots' direction. */
+    flip_timestamps: {
+      type: ParameterType.INT,
+      pretty_name: "Flip timestamps",
+      default: [],
+      array: true,
+    },
     /** If true, then any valid key will end the trial. */
     response_ends_trial: {
       type: ParameterType.BOOL,
@@ -247,6 +254,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
     var choices = assignParameterValue(trial.choices, []);
     var correct_choice = assignParameterValue(trial.correct_choice, undefined);
     var trial_duration = assignParameterValue(trial.trial_duration, 500);
+    var flip_timestamps = assignParameterValue(trial.flip_timestamps, []);
     var response_ends_trial = assignParameterValue(trial.response_ends_trial, true);
     var number_of_apertures = assignParameterValue(trial.number_of_apertures, 1);
     var number_of_dots = assignParameterValue(trial.number_of_dots, 300);
@@ -327,7 +335,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
 
     var RDK = RDK_type;
 
-    /** 
+    /**
       Shape of aperture
       1 - Circle
       2 - Ellipse
@@ -527,6 +535,12 @@ class RdkPlugin implements JsPsychPlugin<Info> {
     //Declare global variable to be defined in startKeyboardListener function and to be used in end_trial function
     var keyboardListener;
 
+    //Flip status {1, -1}
+    var flipStatus = 1;
+
+    //Timeout IDs for flipping.
+    var timeoutIDsFlip = [];
+
     //Declare global variable to store the frame rate of the trial
     var frameRate: number | number[] = []; //How often the monitor refreshes, in ms. Currently an array to store all the intervals. Will be converted into a single number (the average) in end_trial function.
 
@@ -591,6 +605,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
         choices: choices, //The set of valid keys
         correct_choice: correct_choice, //The correct choice(s)
         trial_duration: trial_duration, //The trial duration
+        flip_timestamps: flip_timestamps,
         response_ends_trial: response_ends_trial, //If the response ends the trial
         number_of_apertures: number_of_apertures,
         number_of_dots: number_of_dots,
@@ -660,6 +675,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       //If the parameter is set such that the response ends the trial, then kill the timeout and end the trial
       if (response_ends_trial) {
         window.clearTimeout(timeoutID);
+        timeoutIDsFlip.forEach(window.clearTimeout);
         end_trial();
       }
     } //End of after_response
@@ -954,6 +970,13 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       }
     }
 
+    //Start updating flip status
+    function startFlip() {
+      flip_timestamps.forEach((timestamp: number) => timeoutIDsFlip.push(
+        setTimeout(() => { flipStatus *= -1 }, timestamp)
+      ))
+    };
+
     //Draw the dots on the canvas after they're updated
     function draw() {
       //Load in the current set of dot array for easy handling
@@ -1165,10 +1188,10 @@ class RdkPlugin implements JsPsychPlugin<Info> {
 
     //Updates the x and y coordinates by moving it in the x and y coherent directions
     function constantDirectionUpdate(dot) {
-      dot.x += dot.vx;
-      dot.y += dot.vy;
-      dot.latestXMove = dot.vx;
-      dot.latestYMove = dot.vy;
+      dot.x += dot.vx * flipStatus;
+      dot.y += dot.vy * flipStatus;
+      dot.latestXMove = dot.vx * flipStatus;
+      dot.latestYMove = dot.vy * flipStatus;
       return dot;
     }
 
@@ -1227,12 +1250,12 @@ class RdkPlugin implements JsPsychPlugin<Info> {
       //If it is a square or rectangle, re-insert on one of the opposite edges
       if (apertureType == 3 || apertureType == 4) {
         /** The formula for calculating whether a dot appears from the vertical edge (left or right edges) is dependent on the direction of the dot and the ratio of the vertical and horizontal edge lengths.
-          E.g.  
+          E.g.
           Aperture is 100 px high and 200px wide
           Dot is moving 3 px in x direction and 4px in y direction
           Weight on vertical edge (sides)           = (100/(100+200)) * (|3| / (|3| + |4|)) = 1/7
           Weight on horizontal edge (top or bottom) = (200/(100+200)) * (|4| / (|3| + |4|)) = 8/21
-        
+
           The weights above are the ratios to one another.
           E.g. (cont.)
           Ratio (vertical edge : horizontal edge) == (1/7 : 8/21)
@@ -1370,6 +1393,7 @@ class RdkPlugin implements JsPsychPlugin<Info> {
 
       //Start to listen to subject's key responses
       startKeyboardListener();
+      startFlip();
 
       //Delare a timestamp
       var previousTimestamp;


### PR DESCRIPTION
This PR improves PLUGIN-RDK and adds a function that flip the direction of coherent dots.

You can change the direction of moving dots oppositely during a trial as many times as you want.

Information about added parameter follows below:
Name: flip_timestamps
Type: Array<number>
Default: []

This function is similar one implemented in this study, where dots' directions are flipped probabilistically.
https://elifesciences.org/articles/08825

# How to verify
please `cd plugin-rdk`, `npm i` and `npm run build`.
I modified `example1.html` so you can check how it works.

Thank you in advance!