### PR TITLE
html-vas-response 2.1.0

### DIFF
--- a/.changeset/clean-buckets-chew.md
+++ b/.changeset/clean-buckets-chew.md
@@ -2,4 +2,6 @@
 "@jspsych-contrib/plugin-html-vas-response": minor
 ---
 
+Fixes an issue where drag events caused the scale to become unresponsive and the `not-allowed` cursor to appear.
+
 html-vas-response 2.0.0

--- a/.changeset/clean-buckets-chew.md
+++ b/.changeset/clean-buckets-chew.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-html-vas-response": minor
+---
+
+html-vas-response 2.0.0

--- a/packages/plugin-html-vas-response/README.md
+++ b/packages/plugin-html-vas-response/README.md
@@ -7,7 +7,7 @@ This plugin collects responses to an arbitrary HTML string using a point-and-cli
 ## Loading
 
 ```js
-<script src="https://unpkg.com/@jspsych-contrib/plugin-html-vas-response@2.0.0"></script>
+<script src="https://unpkg.com/@jspsych-contrib/plugin-html-vas-response@2.1.0"></script>
 ```
 
 ## Compatibility

--- a/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
+++ b/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
@@ -20,6 +20,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | marker_draggable | Boolean | true | Allows the user to drag the response marker |
 | scale_width | integer | `null` |  The width of the VAS in pixels. If left `null`, then the width will be equal to the widest element in the display. |
 | scale_height | integer | 40 | The height of the clickable region around the VAS in pixels. |
+| hline_pct | integer | 100 | The width of the horizontal line as a percentage of the width of the clickable region (capped at 100). Setting this to less than 100 makes it easier for the user to select the extreme ends of the scale. |
 | scale_colour | string | `'black'` | The colour of the scale (the horizontal line). Anything that would make a valid CSS `background` property can be used here; e.g., `'linear-gradient(to right, blue, red)'` |
 | scale_cursor | string | `'pointer'` | The style of the cursor when the clickable part of the scale is hovered over. |
 | marker_colour | string | `'rgba(0, 0, 0, 0.5)'` | The colour of the participant's response marker. Anything that would make a valid CSS `background` property can be used here; e.g., `'linear-gradient(to top, blue, red)'` |

--- a/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
+++ b/packages/plugin-html-vas-response/docs/jspsych-html-vas-response.md
@@ -17,6 +17,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | resp_fcn                     | function           | `null`     | A function called when the participant clicks on the scale. The current location of the participant's response (between 0 and 1) is provided as an input. |
 | ticks                     | Boolean           | `true`     | Specifies whether smaller vertical tick marks should accompany the labels. |
 | n_scale_points                     | integer           | `null`     | If the scale should have some set of discrete clickable points (such that the tick mark will be rounded to the nearest such point), this parameter can be used specify the number of such points. If not, set this to `null`. |
+| marker_draggable | Boolean | true | Allows the user to drag the response marker |
 | scale_width | integer | `null` |  The width of the VAS in pixels. If left `null`, then the width will be equal to the widest element in the display. |
 | scale_height | integer | 40 | The height of the clickable region around the VAS in pixels. |
 | scale_colour | string | `'black'` | The colour of the scale (the horizontal line). Anything that would make a valid CSS `background` property can be used here; e.g., `'linear-gradient(to right, blue, red)'` |

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -25,6 +25,7 @@ var trial = {
     "90%",
     "100%<br>Always",
   ],
+  hline_pct: 90,
   resp_fcn: function (ppn) {
     var pct = Math.round(100 * ppn);
     var resp_disp = document.getElementById("resp-disp");

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -25,7 +25,7 @@ var trial = {
     "90%",
     "100%<br>Always",
   ],
-  hline_pct: 110,
+  hline_pct: 90,
   resp_fcn: function (ppn) {
     var pct = Math.round(100 * ppn);
     var resp_disp = document.getElementById("resp-disp");

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -12,7 +12,6 @@ var trial = {
   ticks: false,
   scale_width: 500,
   scale_colour: "black",
-  marker_draggable: true,
   labels: [
     "0%<br>Never",
     "10%",

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -12,6 +12,7 @@ var trial = {
   ticks: false,
   scale_width: 500,
   scale_colour: "black",
+  marker_draggable: true,
   labels: [
     "0%<br>Never",
     "10%",

--- a/packages/plugin-html-vas-response/examples/expt.js
+++ b/packages/plugin-html-vas-response/examples/expt.js
@@ -25,7 +25,7 @@ var trial = {
     "90%",
     "100%<br>Always",
   ],
-  hline_pct: 90,
+  hline_pct: 110,
   resp_fcn: function (ppn) {
     var pct = Math.round(100 * ppn);
     var resp_disp = document.getElementById("resp-disp");

--- a/packages/plugin-html-vas-response/index.js
+++ b/packages/plugin-html-vas-response/index.js
@@ -42,7 +42,7 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
       marker_draggable: {
         type: jspsych.ParameterType.BOOL,
         pretty_name: "Marker draggable",
-        default: false,
+        default: true,
       },
       /** The width of the VAS in pixels.
        * If left `null`, then the width will be equal to the widest element in the display. */

--- a/packages/plugin-html-vas-response/index.js
+++ b/packages/plugin-html-vas-response/index.js
@@ -315,10 +315,10 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
         // document.addEventListener("dblclick", function() {mouse_state = 'down'});
         document.addEventListener("mouseup", function() {mouse_state = 'up'});
         document.addEventListener("dragend", function() {mouse_state = 'up'});
-        function drag_update(e, test) {
+        function drag_update(e, test_mouse_state) {
           var do_update = true;
-          test = test ?? true;
-          if (test) {
+          test_mouse_state = test_mouse_state ?? true; // test by default
+          if (test_mouse_state) {
             if (mouse_state == 'up') {
               do_update = false
             }
@@ -330,7 +330,8 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
         vas.addEventListener("mousemove", drag_update);
         vas.addEventListener("drag", drag_update);
         vas.addEventListener("touchmove", function(e) {
-          drag_update(e, false)
+          e.preventDefault(); // So that whole screen doesn't move in MS Edge
+          drag_update(e, false) // Don't test whether mouse is down
         });
       }
 

--- a/packages/plugin-html-vas-response/index.js
+++ b/packages/plugin-html-vas-response/index.js
@@ -57,8 +57,8 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
         pretty_name: "VAS height",
         default: 40,
       },
-      /** The width of the horizontal line as a percentage of the width of the clickable region.
-       * Setting this to less than 100 makes it easier to select the extreme ends of the scale. */
+      /** The width of the horizontal line as a percentage of the width of the clickable region (capped at 100).
+       * Setting this to less than 100 makes it easier for the user to select the extreme ends of the scale. */
       hline_pct: {
         type: jspsych.ParameterType.INT,
         pretty_name: "Horizontal line width percentage",
@@ -185,6 +185,11 @@ var jsPsychHtmlVasResponse = (function (jspsych) {
       this.jsPsych = jsPsych;
     }
     trial(display_element, trial) {
+      // constrain hline_pct to < 100
+      if (trial.hline_pct > 100) {
+        console.log('hline_pct is greater than 100! This makes no sense. Setting to 100.');
+        trial.hline_pct = 100;
+      }
       // half of the thumb width value from jspsych.css, used to adjust the label positions
       var half_thumb_width = 7.5;
       var html = '<div id="jspsych-html-vas-response-wrapper" style="margin: 100px 0px;">';

--- a/packages/plugin-html-vas-response/package.json
+++ b/packages/plugin-html-vas-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jspsych-contrib/plugin-html-vas-response",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "This plugin collects responses to an arbitrary HTML string using a point-and-click visual analogue scale.",
   "unpkg": "dist/index.browser.min.js",
   "files": [


### PR DESCRIPTION
Added several new features:

- Option to make response marker draggable (with both touches and clicks)
- Option to make horizontal line width some percentage (<100) of the width of the clickable region, making it easier to select the extreme ends of the scale

I've tested this on Chrome, Edge, and Firefox and it works as expected.