### PR TITLE
Handling drag events and making plugin touch-responsive

### DIFF
--- a/.changeset/big-dots-exercise.md
+++ b/.changeset/big-dots-exercise.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-ios": patch
+---
+
+Handling drag events and making plugin touch-responsive

--- a/packages/plugin-ios/examples/classic.html
+++ b/packages/plugin-ios/examples/classic.html
@@ -3,7 +3,7 @@
 <html>
 	<head>
 		<script src="https://unpkg.com/jspsych@8"></script>
-		<script src="../dist/index.browser.js"></script>
+		<script src="../index.js"></script>
 		<link href="https://unpkg.com/jspsych@8/css/jspsych.css" rel="stylesheet" type="text/css" />
 	</head>
 <body>

--- a/packages/plugin-ios/examples/group.html
+++ b/packages/plugin-ios/examples/group.html
@@ -3,7 +3,7 @@
 <html>
 	<head>
 		<script src="https://unpkg.com/jspsych@8"></script>
-		<script src="../dist/index.browser.js"></script>
+		<script src="../index.js"></script>
 		<link href="https://unpkg.com/jspsych@8/css/jspsych.css" rel="stylesheet" type="text/css" />
 	</head>
 <body>
@@ -19,8 +19,12 @@
 	  type: jsPsychIos,
 	  prompt: 'Move the circles so that they represent your relationship',
 	  left_label: 'Self',
-	  right_label: 'Other',
-	  movable_circle: 'left'
+	  right_label: 'Group',
+	  movable_circle: 'left',
+	  both_move: false,
+	  left_diam: 100,
+	  right_diam: 200,
+	  arrows: true
 	};
 
 	jsPsych.run([trial]);

--- a/packages/plugin-ios/index.js
+++ b/packages/plugin-ios/index.js
@@ -17,11 +17,11 @@ var jsPsychIos = (function (jspsych) {
         pretty_name: "Movable circle",
         default: "right",
       },
-      /** Specifies if both circles move (`true`), or just one of them (`false`). */
+      /** Specifies if both circles move (`true`, default), or just one of them (`false`). */
       both_move: {
         type: jspsych.ParameterType.BOOL,
         pretty_name: "Both circles move?",
-        default: "one",
+        default: true,
       },
       /** Specifies which circle is in front of the other. */
       front_circle: {
@@ -426,23 +426,21 @@ var jsPsychIos = (function (jspsych) {
         }
       };
       // Handle touch events
-      clickable_area.ontouchstart = function (e) {
+      clickable_area.addEventListener('touchstart', function (e) {
         circles_movable = true;
         update_circles(e.changedTouches[e.changedTouches.length - 1].clientX);
         var continue_button = document.getElementById("jspsych-ios-next");
         continue_button.disabled = false;
-      };
-      clickable_area.ontouchend = function (e) {
-        circles_movable = false;
-      };
-      clickable_area.ontouchleave = function (e) {
-        circles_movable = false;
-      };
-      clickable_area.ontouchmove = function (e) {
+      });
+      clickable_area.addEventListener('touchend', function(e) {circles_movable = false;});
+      clickable_area.addEventListener('touchleave', function(e) {circles_movable = false;});
+      clickable_area.addEventListener('touchmove', function (e) {
         if (circles_movable) {
           update_circles(e.changedTouches[e.changedTouches.length - 1].clientX);
         }
-      };
+      });
+      // Handle drag events
+      document.addEventListener("dragstart", function(e) {e.preventDefault()});
 
       // Data storage
       var response = {

--- a/packages/plugin-ios/index.js
+++ b/packages/plugin-ios/index.js
@@ -435,6 +435,7 @@ var jsPsychIos = (function (jspsych) {
       clickable_area.addEventListener('touchend', function(e) {circles_movable = false;});
       clickable_area.addEventListener('touchleave', function(e) {circles_movable = false;});
       clickable_area.addEventListener('touchmove', function (e) {
+        e.preventDefault(); // So that whole screen doesn't move in MS Edge
         if (circles_movable) {
           update_circles(e.changedTouches[e.changedTouches.length - 1].clientX);
         }


### PR DESCRIPTION
This update:
- ensures drag events are handled properly
- makes the plugin touch-responsive
- fixes an issue where the default value of `both_move` was `"one"` rather than `true`