### PR TITLE
add name identified to package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@jspsych/jspsych-contrib",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Adds a name identifier to the root package to make repo ID easier for jspsych-dev tools.