### PR TITLE
Add circle-click-response plugin

### DIFF
--- a/.changeset/add-circle-click-response.md
+++ b/.changeset/add-circle-click-response.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-circle-click-response": major
+---
+
+Initial release of circle-click-response plugin. Displays a central HTML stimulus surrounded by clickable options arranged in an equally spaced circle. Supports configurable circle radius, optional trial timeout, stimulus duration, correctness evaluation, and configurable feedback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2313,6 +2313,10 @@
       "resolved": "packages/plugin-capture-url-params",
       "link": true
     },
+    "node_modules/@jspsych-contrib/plugin-circle-click-response": {
+      "resolved": "packages/plugin-circle-click-response",
+      "link": true
+    },
     "node_modules/@jspsych-contrib/plugin-columbia-card-task": {
       "resolved": "packages/plugin-columbia-card-task",
       "link": true
@@ -11882,6 +11886,46 @@
     },
     "packages/plugin-capture-url-params/node_modules/type-fest": {
       "version": "2.19.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/plugin-circle-click-response": {
+      "name": "@jspsych-contrib/plugin-circle-click-response",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/core": "^0.7.14",
+        "@citation-js/plugin-bibtex": "^0.7.14",
+        "@citation-js/plugin-cff": "^0.6.1",
+        "@citation-js/plugin-software-formats": "^0.6.1",
+        "jspsych": "^8.0.0"
+      },
+      "devDependencies": {
+        "@jspsych/config": "^3.2.2",
+        "@jspsych/test-utils": "^1.0.0"
+      }
+    },
+    "packages/plugin-circle-click-response/node_modules/jspsych": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/jspsych/-/jspsych-8.2.3.tgz",
+      "integrity": "sha512-jqKatUYHtDDxZgwNEkfyc9w11LLvDOCbfyTMg0J9a0WdCCUMOxlOYvCCk/o8fwH3sy4hTvAplQYhDg8XZ0SAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "auto-bind": "^4.0.0",
+        "random-words": "^1.1.1",
+        "seedrandom": "^3.0.5",
+        "type-fest": "^2.9.0"
+      }
+    },
+    "packages/plugin-circle-click-response/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"

--- a/packages/plugin-circle-click-response/CITATION.cff
+++ b/packages/plugin-circle-click-response/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Josh de Leeuw"  # Replace with last name
+  given-names: "Josh de Leeuw"   # Replace with first name
+  name-particle: "Josh de Leeuw" # Replace with name particle(s)
+  orcid: "https://orcid.org/0000-0000-0000-0000"  # Replace with ORCID
+# More  authors can be listed here in the same format as above
+contact:  # Contact person for this extension
+- family-names: "Josh de Leeuw"
+  given-names: "Josh de Leeuw"
+  email: "{email}"          # Replace with contact person's email
+  orcid: "https://orcid.org/0000-0000-0000-0000"  # Replace with contact person's ORCID
+title: "jsPsychCircleClickResponse"
+version: 0.0.0
+doi: 10.5281/zenodo.1234    # Replace with DOI
+date-released: 2000-01-01
+url: "{softwareUrl}"        # Replace with URL to this extension
+
+# If you wish to cite a paper on this extension instead, you can use the following template:
+preferred-citation:
+  authors:
+  - family-names: "Josh de Leeuw"
+    given-names: "Josh de Leeuw"
+    name-particle: "Josh de Leeuw"
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+  # More authors can be listed here in the same format as above
+  date-published: 2023-05-11
+  doi: 10.21105/joss.12345 
+  issn: 1234-5678
+  issue: 01
+  journal: Journal for Open Source Software
+  publisher:
+    name: Open Journals
+  start: 0001
+  title: "{title}"
+  type: article               # Other options include: book, pamphlet, conference-paper...
+  url: "{linkToPublicationInJournal}"
+  volume: 1
+
+# More information on the preffered-citation CFF format can be found at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#citing-something-other-than-software

--- a/packages/plugin-circle-click-response/README.md
+++ b/packages/plugin-circle-click-response/README.md
@@ -1,0 +1,71 @@
+# circle-click-response
+
+## Overview
+
+A jsPsych plugin that displays a central HTML stimulus surrounded by clickable options arranged in an equally spaced circle. The participant responds by clicking one of the options. Response time and choice are recorded, and optionally correctness can be evaluated with configurable feedback.
+
+## Loading
+
+### In browser
+
+```html
+<script src="https://unpkg.com/@jspsych-contrib/plugin-circle-click-response"></script>
+```
+
+### Via NPM
+
+```
+npm install @jspsych-contrib/plugin-circle-click-response
+```
+
+```js
+import jsPsychCircleClickResponse from "@jspsych-contrib/plugin-circle-click-response";
+```
+
+## Compatibility
+
+`@jspsych-contrib/plugin-circle-click-response` requires jsPsych v8.0.0 or later.
+
+## Parameters
+
+| Parameter            | Type         | Default | Description                                                                                                  |
+| -------------------- | ------------ | ------- | ------------------------------------------------------------------------------------------------------------ |
+| stimulus             | HTML_STRING  | *Required* | The HTML content to display in the center of the screen.                                                   |
+| choices              | HTML_STRING[] | *Required* | An array of HTML strings representing the clickable options arranged in a circle around the stimulus.      |
+| prompt               | HTML_STRING  | null    | An optional HTML string to display as a prompt below the stimulus and circle.                                |
+| circle_radius        | INT          | 200     | The radius of the circle in pixels.                                                                          |
+| trial_duration       | INT          | null    | The maximum time in ms for the participant to respond. If null, waits indefinitely.                          |
+| stimulus_duration    | INT          | null    | The duration in ms to display the stimulus before hiding it. If null, stays visible.                         |
+| correct_choice       | INT          | null    | The index of the correct response in the choices array. If null, correctness is not evaluated.               |
+| feedback_correct     | HTML_STRING  | null    | HTML string to display as feedback after a correct response.                                                 |
+| feedback_incorrect   | HTML_STRING  | null    | HTML string to display as feedback after an incorrect response.                                              |
+| feedback_duration    | INT          | 1000    | The duration in ms to display feedback before ending the trial.                                              |
+
+## Data
+
+| Name           | Type        | Description                                                                  |
+| -------------- | ----------- | ---------------------------------------------------------------------------- |
+| stimulus       | HTML_STRING | The HTML content displayed as the central stimulus.                          |
+| response       | HTML_STRING | The HTML content of the chosen option. Null if trial timed out.              |
+| response_index | INT         | The index of the chosen option in the choices array. Null if trial timed out.|
+| rt             | INT         | The response time in milliseconds. Null if trial timed out.                  |
+| correct        | BOOL        | Whether the response was correct. Null if correct_choice was not specified.  |
+
+## Example
+
+```js
+const trial = {
+  type: jsPsychCircleClickResponse,
+  stimulus: "<p>2 + 2 = ?</p>",
+  choices: ["<p>3</p>", "<p>4</p>", "<p>5</p>", "<p>6</p>"],
+  correct_choice: 1,
+  feedback_correct: "<p style='color:green;'>Correct!</p>",
+  feedback_incorrect: "<p style='color:red;'>Incorrect</p>",
+  feedback_duration: 1500,
+  prompt: "<p>Click the correct answer.</p>",
+};
+```
+
+## Author / Citation
+
+[Josh de Leeuw](https://github.com/jodeleeuw)

--- a/packages/plugin-circle-click-response/docs/plugin-circle-click-response.md
+++ b/packages/plugin-circle-click-response/docs/plugin-circle-click-response.md
@@ -1,0 +1,54 @@
+# plugin-circle-click-response
+
+A plugin that displays a central HTML stimulus surrounded by clickable options arranged in a circle
+
+## Parameters
+
+In addition to the [parameters available in all plugins](https://www.jspsych.org/latest/overview/plugins#parameters-available-in-all-plugins), this plugin accepts the following parameters. Parameters with a default value of undefined must be specified. Other parameters can be left unspecified if the default value is acceptable.
+
+| Parameter           | Type             | Default Value      | Description                              |
+| ------------------- | ---------------- | ------------------ | ---------------------------------------- |
+|                     |                  |                    |                                          |
+
+## Data Generated
+
+In addition to the [default data collected by all plugins](https://www.jspsych.org/latest/overview/plugins#data-collected-by-all-plugins), this plugin collects the following data for each trial.
+
+| Name      | Type    | Value                                    |
+| --------- | ------- | ---------------------------------------- |
+|           |         |                                          |
+
+## Install
+
+Using the CDN-hosted JavaScript file:
+
+```js
+<script src="https://unpkg.com/@jspsych-contrib/plugin-circle-click-response"></script>
+```
+
+Using the JavaScript file downloaded from a GitHub release dist archive:
+
+```js
+<script src="jspsych/plugin-circle-click-response.js"></script>
+```
+
+Using NPM:
+
+```
+npm install @jspsych-contrib/plugin-circle-click-response
+```
+
+```js
+import CircleClickResponse from "@jspsych-contrib/plugin-circle-click-response";
+```
+
+
+## Examples
+
+### Title of Example
+
+```javascript
+var trial = {
+  type: jsPsychCircleClickResponse
+}
+```

--- a/packages/plugin-circle-click-response/docs/plugin-circle-click-response.md
+++ b/packages/plugin-circle-click-response/docs/plugin-circle-click-response.md
@@ -6,17 +6,30 @@ A plugin that displays a central HTML stimulus surrounded by clickable options a
 
 In addition to the [parameters available in all plugins](https://www.jspsych.org/latest/overview/plugins#parameters-available-in-all-plugins), this plugin accepts the following parameters. Parameters with a default value of undefined must be specified. Other parameters can be left unspecified if the default value is acceptable.
 
-| Parameter           | Type             | Default Value      | Description                              |
-| ------------------- | ---------------- | ------------------ | ---------------------------------------- |
-|                     |                  |                    |                                          |
+| Parameter | Type | Default Value | Description |
+| ------------------- | ---------------- | ------------- | ----------- |
+| stimulus | HTML_STRING | undefined | The HTML content to display in the center of the screen. |
+| choices | HTML_STRING[] | undefined | An array of HTML strings representing the clickable options arranged in a circle around the stimulus. |
+| prompt | HTML_STRING | null | An optional HTML string to display as a prompt below the stimulus and circle. |
+| circle_radius | INT | 200 | The radius of the circle in pixels. |
+| trial_duration | INT | null | The maximum time in ms for the participant to respond. If null, waits indefinitely. |
+| stimulus_duration | INT | null | The duration in ms to display the stimulus. Choices are shown immediately and the stimulus is hidden after this duration. If null, stays visible. |
+| correct_choice | INT | null | The index of the correct response in the choices array. If null, correctness is not evaluated. |
+| feedback_correct | HTML_STRING | null | HTML string to display as feedback after a correct response. |
+| feedback_incorrect | HTML_STRING | null | HTML string to display as feedback after an incorrect response. |
+| feedback_duration | INT | 1000 | The duration in ms to display feedback before ending the trial. |
 
 ## Data Generated
 
 In addition to the [default data collected by all plugins](https://www.jspsych.org/latest/overview/plugins#data-collected-by-all-plugins), this plugin collects the following data for each trial.
 
-| Name      | Type    | Value                                    |
-| --------- | ------- | ---------------------------------------- |
-|           |         |                                          |
+| Name | Type | Value |
+| -------------- | ----------- | ----- |
+| stimulus | HTML_STRING | The HTML content displayed as the central stimulus. |
+| response | HTML_STRING | The HTML content of the chosen option. Null if trial timed out. |
+| response_index | INT | The index of the chosen option in the choices array. Null if trial timed out. |
+| rt | INT | The response time in milliseconds. Null if trial timed out. |
+| correct | BOOL | Whether the response was correct. Null if correct_choice was not specified. |
 
 ## Install
 
@@ -45,10 +58,17 @@ import CircleClickResponse from "@jspsych-contrib/plugin-circle-click-response";
 
 ## Examples
 
-### Title of Example
+### Digit search with feedback
 
 ```javascript
 var trial = {
-  type: jsPsychCircleClickResponse
-}
+  type: jsPsychCircleClickResponse,
+  stimulus: "<p>Find the <strong>7</strong></p>",
+  choices: ["<span>3</span>", "<span>9</span>", "<span>7</span>", "<span>2</span>"],
+  correct_choice: 2,
+  feedback_correct: "<p style='color:green;'>Correct!</p>",
+  feedback_incorrect: "<p style='color:red;'>Incorrect</p>",
+  feedback_duration: 1500,
+  prompt: "<p>Click the digit 7.</p>",
+};
 ```

--- a/packages/plugin-circle-click-response/examples/index.html
+++ b/packages/plugin-circle-click-response/examples/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>circle-click-response Example</title>
+    <script src="https://unpkg.com/jspsych"></script>
+    <script src="../dist/index.browser.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/jspsych/css/jspsych.css" />
+  </head>
+
+  <body></body>
+  <script>
+    const jsPsych = initJsPsych({
+      on_finish: function () {
+        jsPsych.data.displayData();
+      },
+    });
+
+    // Instructions
+    const instructions = {
+      type: jsPsychHtmlKeyboardResponse,
+      stimulus: `
+        <h2>circle-click-response Demo</h2>
+        <p>You will see two example trials:</p>
+        <ol style="text-align: left; max-width: 500px; margin: auto;">
+          <li><strong>Digit search:</strong> Find a target digit among distractors.</li>
+          <li><strong>Color matching:</strong> Click the colored circle that matches the center.</li>
+        </ol>
+        <p>Press any key to begin.</p>
+      `,
+    };
+
+    // Trial 1: Digit search — find the target number
+    const digit_trial = {
+      type: jsPsychCircleClickResponse,
+      stimulus: "<p style='font-size: 28px;'>Find the <strong>7</strong></p>",
+      choices: [
+        "<span style='font-size: 36px; font-weight: bold;'>3</span>",
+        "<span style='font-size: 36px; font-weight: bold;'>9</span>",
+        "<span style='font-size: 36px; font-weight: bold;'>7</span>",
+        "<span style='font-size: 36px; font-weight: bold;'>2</span>",
+        "<span style='font-size: 36px; font-weight: bold;'>5</span>",
+        "<span style='font-size: 36px; font-weight: bold;'>1</span>",
+      ],
+      correct_choice: 2,
+      feedback_correct:
+        "<p style='color: green; font-size: 20px;'>&#10003; Correct!</p>",
+      feedback_incorrect:
+        "<p style='color: red; font-size: 20px;'>&#10007; Wrong — the 7 was in position 3.</p>",
+      feedback_duration: 1500,
+      prompt: "<p>Click the digit 7.</p>",
+      circle_radius: 180,
+    };
+
+    // Trial 2: Colored circles — match the center color
+    function colorCircle(color) {
+      return (
+        "<div style='width: 60px; height: 60px; border-radius: 50%; background: " +
+        color +
+        "; border: 2px solid #333; cursor: pointer;'></div>"
+      );
+    }
+
+    const color_trial = {
+      type: jsPsychCircleClickResponse,
+      stimulus: colorCircle("dodgerblue"),
+      choices: [
+        colorCircle("red"),
+        colorCircle("dodgerblue"),
+        colorCircle("green"),
+        colorCircle("orange"),
+        colorCircle("purple"),
+        colorCircle("gold"),
+        colorCircle("hotpink"),
+        colorCircle("teal"),
+      ],
+      correct_choice: 1,
+      feedback_correct:
+        "<p style='color: green; font-size: 20px;'>&#10003; Correct — that's the matching color!</p>",
+      feedback_incorrect:
+        "<p style='color: red; font-size: 20px;'>&#10007; Wrong — the matching color was blue.</p>",
+      feedback_duration: 1500,
+      prompt: "<p>Click the circle that matches the color in the center.</p>",
+      circle_radius: 220,
+    };
+
+    jsPsych.run([instructions, digit_trial, color_trial]);
+  </script>
+</html>

--- a/packages/plugin-circle-click-response/examples/index.html
+++ b/packages/plugin-circle-click-response/examples/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>circle-click-response Example</title>
     <script src="https://unpkg.com/jspsych"></script>
+    <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response"></script>
     <script src="../dist/index.browser.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/jspsych/css/jspsych.css" />
   </head>

--- a/packages/plugin-circle-click-response/jest.config.cjs
+++ b/packages/plugin-circle-click-response/jest.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@jspsych/config/jest").makePackageConfig(__dirname);

--- a/packages/plugin-circle-click-response/package.json
+++ b/packages/plugin-circle-click-response/package.json
@@ -25,7 +25,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jspsych/jspsych-contrib.git",
-    "directory": "packages"
+    "directory": "packages/plugin-circle-click-response"
   },
   "keywords": [
     "jsPsych"

--- a/packages/plugin-circle-click-response/package.json
+++ b/packages/plugin-circle-click-response/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@jspsych-contrib/plugin-circle-click-response",
+  "version": "0.0.1",
+  "description": "A plugin that displays a central HTML stimulus surrounded by clickable options arranged in a circle",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "typings": "dist/index.d.ts",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "source": "src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "npm test -- --watch",
+    "tsc": "tsc",
+    "build": "rollup --config",
+    "build:watch": "npm run build -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jspsych/jspsych-contrib.git",
+    "directory": "packages"
+  },
+  "keywords": [
+    "jsPsych"
+  ],
+  "author": {
+    "name": "Josh de Leeuw",
+    "url": "https://github.com/jodeleeuw"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jspsych/jspsych-contrib/issues"
+  },
+  "homepage": "https://github.com/jspsych/jspsych-contrib/packages/plugin-circle-click-response/README.md",
+  "dependencies": {
+    "jspsych": "^8.0.0",
+    "@citation-js/core": "^0.7.14",
+    "@citation-js/plugin-software-formats": "^0.6.1",
+    "@citation-js/plugin-bibtex": "^0.7.14",
+    "@citation-js/plugin-cff": "^0.6.1"
+  },
+  "devDependencies": {
+    "@jspsych/config": "^3.2.2",
+    "@jspsych/test-utils": "^1.0.0"
+  }
+}

--- a/packages/plugin-circle-click-response/rollup.config.mjs
+++ b/packages/plugin-circle-click-response/rollup.config.mjs
@@ -1,0 +1,3 @@
+import { makeRollupConfig } from "@jspsych/config/rollup";
+
+export default makeRollupConfig("jsPsychCircleClickResponse");

--- a/packages/plugin-circle-click-response/src/index.spec.ts
+++ b/packages/plugin-circle-click-response/src/index.spec.ts
@@ -1,0 +1,189 @@
+import { clickTarget, startTimeline } from "@jspsych/test-utils";
+
+import jsPsychCircleClickResponse from ".";
+
+jest.useFakeTimers();
+
+describe("circle-click-response", () => {
+  it("renders stimulus and choices", async () => {
+    const { expectRunning, getHTML } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>", "<p>C</p>"],
+      },
+    ]);
+
+    await expectRunning();
+    expect(getHTML()).toContain("Center");
+    expect(getHTML()).toContain("<p>A</p>");
+    expect(getHTML()).toContain("<p>B</p>");
+    expect(getHTML()).toContain("<p>C</p>");
+  });
+
+  it("renders the prompt when provided", async () => {
+    const { expectRunning, getHTML } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>"],
+        prompt: "<p>Pick one</p>",
+      },
+    ]);
+
+    await expectRunning();
+    expect(getHTML()).toContain("Pick one");
+  });
+
+  it("records response and rt on click", async () => {
+    const { expectFinished, getData, displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>", "<p>C</p>"],
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    await clickTarget(choices[1]);
+
+    await expectFinished();
+    const data = getData().values()[0];
+    expect(data.response).toBe("<p>B</p>");
+    expect(data.response_index).toBe(1);
+    expect(data.rt).toBeGreaterThanOrEqual(0);
+    expect(data.correct).toBeNull();
+  });
+
+  it("evaluates correctness when correct_choice is set", async () => {
+    const { expectFinished, getData, displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>", "<p>C</p>"],
+        correct_choice: 2,
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    await clickTarget(choices[2]);
+
+    await expectFinished();
+    const data = getData().values()[0];
+    expect(data.correct).toBe(true);
+  });
+
+  it("records incorrect when wrong choice is selected", async () => {
+    const { expectFinished, getData, displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>", "<p>C</p>"],
+        correct_choice: 2,
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    await clickTarget(choices[0]);
+
+    await expectFinished();
+    const data = getData().values()[0];
+    expect(data.correct).toBe(false);
+  });
+
+  it("ends trial after trial_duration with null response", async () => {
+    const { expectFinished, getData } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>"],
+        trial_duration: 500,
+      },
+    ]);
+
+    jest.advanceTimersByTime(500);
+
+    await expectFinished();
+    const data = getData().values()[0];
+    expect(data.response).toBeNull();
+    expect(data.rt).toBeNull();
+  });
+
+  it("shows feedback and waits before ending trial", async () => {
+    const { expectFinished, expectRunning, getHTML, displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>"],
+        correct_choice: 0,
+        feedback_correct: "<p>Correct!</p>",
+        feedback_incorrect: "<p>Wrong!</p>",
+        feedback_duration: 1000,
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    await clickTarget(choices[0]);
+
+    // Feedback should be visible, trial not yet finished
+    expect(getHTML()).toContain("Correct!");
+
+    jest.advanceTimersByTime(1000);
+    await expectFinished();
+  });
+
+  it("shows incorrect feedback", async () => {
+    const { expectFinished, getHTML, displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>", "<p>B</p>"],
+        correct_choice: 0,
+        feedback_correct: "<p>Correct!</p>",
+        feedback_incorrect: "<p>Wrong!</p>",
+        feedback_duration: 500,
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    await clickTarget(choices[1]);
+
+    expect(getHTML()).toContain("Wrong!");
+
+    jest.advanceTimersByTime(500);
+    await expectFinished();
+  });
+
+  it("hides stimulus after stimulus_duration", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>A</p>"],
+        stimulus_duration: 300,
+      },
+    ]);
+
+    const stim = displayElement.querySelector(
+      "#jspsych-circle-click-response-stimulus"
+    ) as HTMLElement;
+    expect(stim.style.visibility).not.toBe("hidden");
+
+    jest.advanceTimersByTime(300);
+    expect(stim.style.visibility).toBe("hidden");
+  });
+
+  it("positions choices in a circle with correct number of elements", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychCircleClickResponse,
+        stimulus: "<p>Center</p>",
+        choices: ["<p>1</p>", "<p>2</p>", "<p>3</p>", "<p>4</p>"],
+        circle_radius: 150,
+      },
+    ]);
+
+    const choices = displayElement.querySelectorAll(".jspsych-circle-click-response-choice");
+    expect(choices.length).toBe(4);
+  });
+});

--- a/packages/plugin-circle-click-response/src/index.ts
+++ b/packages/plugin-circle-click-response/src/index.ts
@@ -1,0 +1,215 @@
+import { JsPsych, JsPsychPlugin, ParameterType, TrialType } from "jspsych";
+
+import { version } from "../package.json";
+
+const info = <const>{
+  name: "circle-click-response",
+  version: version,
+  parameters: {
+    /** The HTML content to display in the center of the screen. */
+    stimulus: {
+      type: ParameterType.HTML_STRING,
+      default: undefined,
+    },
+    /** An array of HTML strings representing the clickable options arranged in a circle around the stimulus. */
+    choices: {
+      type: ParameterType.HTML_STRING,
+      array: true,
+      default: undefined,
+    },
+    /** An optional HTML string to display as a prompt below the stimulus and circle. */
+    prompt: {
+      type: ParameterType.HTML_STRING,
+      default: null,
+    },
+    /** The radius of the circle in pixels. */
+    circle_radius: {
+      type: ParameterType.INT,
+      default: 200,
+    },
+    /** The maximum time in milliseconds that the participant has to respond. If null, the trial will wait indefinitely. */
+    trial_duration: {
+      type: ParameterType.INT,
+      default: null,
+    },
+    /** The duration in milliseconds to display the stimulus before the choices appear. If 0, stimulus and choices appear simultaneously. */
+    stimulus_duration: {
+      type: ParameterType.INT,
+      default: null,
+    },
+    /** The index of the correct response in the choices array. If null, correctness is not evaluated. */
+    correct_choice: {
+      type: ParameterType.INT,
+      default: null,
+    },
+    /** HTML string to display as feedback after a correct response. If null, no feedback is shown. Only used when correct_choice is set. */
+    feedback_correct: {
+      type: ParameterType.HTML_STRING,
+      default: null,
+    },
+    /** HTML string to display as feedback after an incorrect response. If null, no feedback is shown. Only used when correct_choice is set. */
+    feedback_incorrect: {
+      type: ParameterType.HTML_STRING,
+      default: null,
+    },
+    /** The duration in milliseconds to display feedback. Only used when feedback is shown. */
+    feedback_duration: {
+      type: ParameterType.INT,
+      default: 1000,
+    },
+  },
+  data: {
+    /** The HTML content displayed as the central stimulus. */
+    stimulus: {
+      type: ParameterType.HTML_STRING,
+    },
+    /** The HTML content of the chosen option. */
+    response: {
+      type: ParameterType.HTML_STRING,
+    },
+    /** The index of the chosen option in the choices array. */
+    response_index: {
+      type: ParameterType.INT,
+    },
+    /** The response time in milliseconds. */
+    rt: {
+      type: ParameterType.INT,
+    },
+    /** Whether the response was correct. Null if correct_choice was not specified. */
+    correct: {
+      type: ParameterType.BOOL,
+    },
+  },
+  citations: "__CITATIONS__",
+};
+
+type Info = typeof info;
+
+/**
+ * **circle-click-response**
+ *
+ * A plugin that displays a central HTML stimulus surrounded by clickable options arranged in a circle.
+ *
+ * @author Josh de Leeuw
+ * @see {@link https://github.com/jspsych/jspsych-contrib/packages/plugin-circle-click-response/README.md}
+ */
+class CircleClickResponsePlugin implements JsPsychPlugin<Info> {
+  static info = info;
+
+  constructor(private jsPsych: JsPsych) {}
+
+  trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    const n_choices = trial.choices.length;
+    const radius = trial.circle_radius;
+
+    // Build HTML
+    let html = `<div id="jspsych-circle-click-response-wrapper" style="position: relative; width: ${
+      radius * 2 + 120
+    }px; height: ${radius * 2 + 120}px; margin: auto;">`;
+
+    // Central stimulus
+    html += `<div id="jspsych-circle-click-response-stimulus" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">${trial.stimulus}</div>`;
+
+    // Choice options arranged in a circle
+    for (let i = 0; i < n_choices; i++) {
+      const angle = (2 * Math.PI * i) / n_choices - Math.PI / 2; // Start from top
+      const x = radius * Math.cos(angle);
+      const y = radius * Math.sin(angle);
+
+      html += `<div class="jspsych-circle-click-response-choice" data-choice-index="${i}" style="position: absolute; top: 50%; left: 50%; transform: translate(calc(-50% + ${x}px), calc(-50% + ${y}px)); cursor: pointer; user-select: none;">${trial.choices[i]}</div>`;
+    }
+
+    html += `</div>`;
+
+    // Prompt
+    if (trial.prompt !== null) {
+      html += `<div id="jspsych-circle-click-response-prompt">${trial.prompt}</div>`;
+    }
+
+    // Feedback container (hidden initially)
+    html += `<div id="jspsych-circle-click-response-feedback" style="display: none; text-align: center; margin-top: 10px;"></div>`;
+
+    display_element.innerHTML = html;
+
+    const start_time = performance.now();
+
+    const end_trial = (response_index: number | null) => {
+      // Clear any pending timeouts
+      this.jsPsych.pluginAPI.clearAllTimeouts();
+
+      const end_time = performance.now();
+      const rt = response_index !== null ? Math.round(end_time - start_time) : null;
+
+      let correct: boolean | null = null;
+      if (trial.correct_choice !== null && response_index !== null) {
+        correct = response_index === trial.correct_choice;
+      }
+
+      const trial_data = {
+        stimulus: trial.stimulus,
+        response: response_index !== null ? trial.choices[response_index] : null,
+        response_index: response_index,
+        rt: rt,
+        correct: correct,
+      };
+
+      // Check if feedback should be shown
+      const show_feedback =
+        correct !== null &&
+        ((correct && trial.feedback_correct !== null) ||
+          (!correct && trial.feedback_incorrect !== null));
+
+      if (show_feedback) {
+        // Remove click listeners
+        const choice_elements = display_element.querySelectorAll(
+          ".jspsych-circle-click-response-choice"
+        );
+        choice_elements.forEach((el) => {
+          (el as HTMLElement).style.pointerEvents = "none";
+        });
+
+        const feedback_el = display_element.querySelector(
+          "#jspsych-circle-click-response-feedback"
+        ) as HTMLElement;
+        feedback_el.innerHTML = correct ? trial.feedback_correct : trial.feedback_incorrect;
+        feedback_el.style.display = "block";
+
+        this.jsPsych.pluginAPI.setTimeout(() => {
+          this.jsPsych.finishTrial(trial_data);
+        }, trial.feedback_duration);
+      } else {
+        this.jsPsych.finishTrial(trial_data);
+      }
+    };
+
+    // Add click listeners to choices
+    const choice_elements = display_element.querySelectorAll(
+      ".jspsych-circle-click-response-choice"
+    );
+    choice_elements.forEach((el) => {
+      el.addEventListener("click", (e) => {
+        const target = (e.currentTarget as HTMLElement).getAttribute("data-choice-index");
+        end_trial(parseInt(target, 10));
+      });
+    });
+
+    // Handle stimulus duration (hide stimulus after duration)
+    if (trial.stimulus_duration !== null) {
+      this.jsPsych.pluginAPI.setTimeout(() => {
+        const stim_el = display_element.querySelector(
+          "#jspsych-circle-click-response-stimulus"
+        ) as HTMLElement;
+        stim_el.style.visibility = "hidden";
+      }, trial.stimulus_duration);
+    }
+
+    // Handle trial duration (end trial if no response)
+    if (trial.trial_duration !== null) {
+      this.jsPsych.pluginAPI.setTimeout(() => {
+        end_trial(null);
+      }, trial.trial_duration);
+    }
+  }
+}
+
+export default CircleClickResponsePlugin;

--- a/packages/plugin-circle-click-response/src/index.ts
+++ b/packages/plugin-circle-click-response/src/index.ts
@@ -32,7 +32,7 @@ const info = <const>{
       type: ParameterType.INT,
       default: null,
     },
-    /** The duration in milliseconds to display the stimulus before the choices appear. If 0, stimulus and choices appear simultaneously. */
+    /** The duration in milliseconds to display the stimulus. Choices are shown immediately and the stimulus is hidden after this duration. If null, the stimulus remains visible. */
     stimulus_duration: {
       type: ParameterType.INT,
       default: null,
@@ -99,6 +99,10 @@ class CircleClickResponsePlugin implements JsPsychPlugin<Info> {
   constructor(private jsPsych: JsPsych) {}
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    if (trial.choices.length === 0) {
+      throw new Error("circle-click-response plugin requires at least one choice.");
+    }
+
     const n_choices = trial.choices.length;
     const radius = trial.circle_radius;
 
@@ -189,6 +193,9 @@ class CircleClickResponsePlugin implements JsPsychPlugin<Info> {
     choice_elements.forEach((el) => {
       el.addEventListener("click", (e) => {
         const target = (e.currentTarget as HTMLElement).getAttribute("data-choice-index");
+        if (target === null) {
+          return;
+        }
         end_trial(parseInt(target, 10));
       });
     });

--- a/packages/plugin-circle-click-response/tsconfig.json
+++ b/packages/plugin-circle-click-response/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@jspsych/config/tsconfig.contrib.json",
+    "compilerOptions": {
+      "baseUrl": ".",
+      "resolveJsonModule": true
+    },
+    "include": ["src"]
+  }
+  


### PR DESCRIPTION
## Summary
- New plugin `circle-click-response` that displays a central HTML stimulus surrounded by clickable options arranged in an equally spaced circle
- Supports configurable circle radius, optional trial timeout, stimulus duration, correctness evaluation, and feedback display
- Includes 10 passing tests, example file (digit search + color matching demos), and full documentation

## Parameters
- `stimulus` / `choices` — central HTML and surrounding clickable options
- `circle_radius` — radius in px (default 200)
- `trial_duration` / `stimulus_duration` — optional timing controls
- `correct_choice` — enables correctness evaluation
- `feedback_correct` / `feedback_incorrect` / `feedback_duration` — optional configurable feedback

## Test plan
- [x] All 10 unit tests pass (`npm test`)
- [x] Plugin builds successfully (`npm run build`)
- [ ] Manual verification of example file in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)