### PR TITLE
Restrict workflow token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build, lint, and test on Node.js ${{ matrix.node }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,16 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
     
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds explicit workflow token permissions.

- Sets the build workflow to read-only contents access because it only checks out code, installs dependencies, builds, and runs tests.
- Sets the release workflow to read-only by default.
- Grants the release job write permissions for contents and pull requests because the Changesets release automation may need to create/update release PRs and publish release-related changes.