### PR TITLE
Add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Adds a CodeQL workflow for JavaScript/TypeScript static analysis.

## Motivation

This addresses the OpenSSF Scorecard recommendation:

> It is SUGGESTED that static source code analysis occur on every commit or at least daily.

The workflow runs on pushes to main, pull requests targeting main, a daily schedule, and manual dispatch.

## Notes

- Uses GitHub's CodeQL action for JavaScript/TypeScript analysis.
- Keeps permissions scoped to read repository contents and write code scanning results.