### PR TITLE
chore: update husky to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@changesets/changelog-github": "^0.4.0",
         "@changesets/cli": "^2.16.0",
         "@jspsych/config": "^3.2.2",
-        "husky": "^7.0.1",
+        "husky": "^9.1.7",
         "import-sort-style-module": "^6.0.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.3.2",
@@ -6251,14 +6251,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.4",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -12953,7 +12955,7 @@
         "@changesets/cli": "^2.29.5",
         "@jspsych/config": "^3.2.2",
         "@jspsych/test-utils": "^1.0.0",
-        "husky": "^7.0.4",
+        "husky": "^9.1.7",
         "tsup": "^8.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build -ws",
     "update-unpkg-links": "gulp updateUnpkgLinks",
     "update-readme": "gulp updateReadme",
-    "prepare": "husky install",
+    "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version && npm install && npm run update-unpkg-links && npm run update-readme",
     "changeset:publish": "npm run build && changeset publish"
@@ -25,7 +25,7 @@
     "@changesets/changelog-github": "^0.4.0",
     "@changesets/cli": "^2.16.0",
     "@jspsych/config": "^3.2.2",
-    "husky": "^7.0.1",
+    "husky": "^9.1.7",
     "import-sort-style-module": "^6.0.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.3.2",

--- a/packages/plugin-slide-to-continue/package.json
+++ b/packages/plugin-slide-to-continue/package.json
@@ -46,7 +46,7 @@
     "@changesets/cli": "^2.29.5",
     "@jspsych/config": "^3.2.2",
     "@jspsych/test-utils": "^1.0.0",
-    "husky": "^7.0.4",
+    "husky": "^9.1.7",
     "tsup": "^8.5.0"
   }
 }


### PR DESCRIPTION
Summary:
- Updates Husky from v7 to v9.
- Updates the root prepare script from `husky install` to `husky`.
- Removes the old `.husky/_/husky.sh` sourcing line from `.husky/pre-commit`.
- Updates the direct Husky dependency in `packages/plugin-slide-to-continue`.
- Preserves the existing pre-commit behavior: `npx lint-staged`.

Verification:
- `npm run prepare` passed.
- `npx lint-staged` completed with no staged files found.
- `npm test -- --watch=false` passed:
  - 42 test suites passed
  - 5 test suites skipped
  - 313 tests passed
  - 9 tests skipped