### PR TITLE
feat(plugin-bart): improve CSS customizability

### DIFF
--- a/.changeset/bart-css-customization.md
+++ b/.changeset/bart-css-customization.md
@@ -1,0 +1,9 @@
+---
+"@jspsych-contrib/plugin-bart": minor
+---
+
+Improve CSS customizability of the BART plugin:
+
+- Add `value_text_color`, `label_text_color`, `info_box_border_color`, and `info_box_background_color` parameters for the info box text, borders, and backgrounds. Their defaults are derived from `currentColor`, so the display now adapts to light/dark page themes without consumer overrides, replacing the previously hard-coded `#333`/`#666`/`#f0f0f0` values.
+- Add a `balloon_stage_height` parameter (default 400) to control the balloon stage height, which was previously hard-coded and required `!important` overrides.
+- Document the existing `max_pumps` parameter in the README.

--- a/packages/plugin-bart/README.md
+++ b/packages/plugin-bart/README.md
@@ -44,6 +44,16 @@ import jsPsychBart from "@jspsych-contrib/plugin-bart";
 | pump_animation_duration   | INT     | 200           | Duration of pump animation in milliseconds.                                                       |
 | pop_animation_duration    | INT     | 300           | Duration of pop animation in milliseconds.                                                        |
 | balloon_color             | STRING  | "#ff0000"     | Base color of the balloon (CSS color value).                                                      |
+| balloon_stage_height      | INT     | 400           | Height of the balloon stage (the area the balloon is drawn in), in pixels. The balloon scales to fit this area. |
+| value_text_color          | STRING  | "currentColor" | CSS color for the value/total point numbers in the info boxes. Defaults to `currentColor` so it inherits the surrounding text color and adapts to light/dark themes. |
+| label_text_color          | STRING  | "color-mix(in srgb, currentColor 60%, transparent)" | CSS color for the labels above the value/total point numbers. Defaults to a muted version of the surrounding text color so it adapts to light/dark themes. |
+| info_box_border_color     | STRING  | "currentColor" | CSS color for the info box borders. Defaults to `currentColor` so it inherits the surrounding text color and adapts to light/dark themes. |
+| info_box_background_color | STRING  | "color-mix(in srgb, currentColor 6%, transparent)" | CSS color for the info box backgrounds. Defaults to a subtle tint of the surrounding text color so it adapts to light/dark themes. |
+| max_pumps                 | INT     | 20            | Maximum expected pumps, used for visual scaling. The balloon scales to fit the stage at this pump count. Does **not** prevent pumping beyond this value (use `pop_threshold` for that). |
+
+## Theming
+
+By default, the info box text, borders, and backgrounds are derived from `currentColor` (the inherited text color), so the display adapts to light and dark page themes without any per-trial configuration. To take explicit control, set `value_text_color`, `label_text_color`, `info_box_border_color`, and `info_box_background_color` to any CSS color value. The balloon stage size is controlled with `balloon_stage_height` (no `!important` overrides needed).
 
 ## Data Generated
 
@@ -105,10 +115,16 @@ const trial = {
   balloon_color: "#00aaff",
   balloon_starting_size: 0.3,
   balloon_size_increment: 0.08,
+  balloon_stage_height: 500,
   pump_button_label: "Inflate",
   collect_button_label: "Cash Out",
   show_balloon_value: true,
-  show_total_points: false
+  show_total_points: false,
+  // Explicit theming (defaults adapt to light/dark themes automatically)
+  value_text_color: "#ffffff",
+  label_text_color: "#cccccc",
+  info_box_border_color: "#00aaff",
+  info_box_background_color: "#102030"
 };
 ```
 

--- a/packages/plugin-bart/docs/plugin-bart.md
+++ b/packages/plugin-bart/docs/plugin-bart.md
@@ -24,6 +24,11 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | pump_animation_duration    | int     | 200           | Duration of pump animation in milliseconds.                                                                                              |
 | pop_animation_duration     | int     | 300           | Duration of pop animation in milliseconds.                                                                                               |
 | balloon_color              | string  | "#ff0000"     | Base color of the balloon (any CSS color).                                                                                               |
+| balloon_stage_height       | int     | 400           | Height of the balloon stage (the area the balloon is drawn in), in pixels. The balloon scales to fit this area.                          |
+| value_text_color           | string  | "currentColor" | CSS color for the value/total point numbers in the info boxes. Defaults to `currentColor` so it adapts to light/dark themes.            |
+| label_text_color           | string  | "color-mix(in srgb, currentColor 60%, transparent)" | CSS color for the labels above the value/total point numbers. Defaults to a muted, theme-adaptive color. |
+| info_box_border_color      | string  | "currentColor" | CSS color for the info box borders. Defaults to `currentColor` so it adapts to light/dark themes.                                       |
+| info_box_background_color  | string  | "color-mix(in srgb, currentColor 6%, transparent)" | CSS color for the info box backgrounds. Defaults to a subtle, theme-adaptive tint.                       |
 | max_pumps                  | int     | 20            | Maximum expected pumps for visual scaling. The balloon will scale to fit the container at this pump count. Does not prevent pumping beyond this value. |
 
 ## Data Generated

--- a/packages/plugin-bart/src/index.spec.ts
+++ b/packages/plugin-bart/src/index.spec.ts
@@ -280,6 +280,78 @@ describe("jsPsych BART plugin", () => {
     expect(getHTML()).toContain("#0000ff");
   });
 
+  it("should apply custom info box and text colors", async () => {
+    const { getHTML } = await startTimeline([
+      {
+        type: jsPsychBart,
+        pop_threshold: 10,
+        value_text_color: "rgb(10, 20, 30)",
+        label_text_color: "rgb(40, 50, 60)",
+        info_box_border_color: "rgb(70, 80, 90)",
+        info_box_background_color: "rgb(100, 110, 120)",
+      },
+    ]);
+
+    const html = getHTML();
+    expect(html).toContain("rgb(10, 20, 30)");
+    expect(html).toContain("rgb(40, 50, 60)");
+    expect(html).toContain("rgb(70, 80, 90)");
+    expect(html).toContain("rgb(100, 110, 120)");
+  });
+
+  it("should use currentColor-based defaults for info box and text colors", async () => {
+    const { getHTML } = await startTimeline([
+      {
+        type: jsPsychBart,
+        pop_threshold: 10,
+      },
+    ]);
+
+    const html = getHTML();
+    // Defaults inherit the surrounding text color so they adapt to light/dark themes
+    expect(html).toContain("currentColor");
+    // Hard-coded legacy colors should no longer be present
+    expect(html).not.toContain("#333");
+    expect(html).not.toContain("#666");
+    expect(html).not.toContain("#f0f0f0");
+  });
+
+  it("should apply a custom balloon stage height", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychBart,
+        pop_threshold: 10,
+        balloon_stage_height: 600,
+      },
+    ]);
+
+    const container = displayElement.querySelector(
+      "#jspsych-bart-balloon-container"
+    ) as HTMLElement;
+    expect(container.style.height).toBe("600px");
+
+    const svg = displayElement.querySelector("#jspsych-bart-balloon-svg") as SVGSVGElement;
+    expect(svg.getAttribute("height")).toBe("600");
+    // Width preserves the 300:400 (0.75) aspect ratio of the viewBox
+    expect(svg.getAttribute("width")).toBe("450");
+    // viewBox stays at the original coordinate system so balloon math is unaffected
+    expect(svg.getAttribute("viewBox")).toBe("0 0 300 400");
+  });
+
+  it("should default the balloon stage height to 400px", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychBart,
+        pop_threshold: 10,
+      },
+    ]);
+
+    const container = displayElement.querySelector(
+      "#jspsych-bart-balloon-container"
+    ) as HTMLElement;
+    expect(container.style.height).toBe("400px");
+  });
+
   it("should scale balloon with custom starting size and increment", async () => {
     const { displayElement } = await startTimeline([
       {

--- a/packages/plugin-bart/src/index.ts
+++ b/packages/plugin-bart/src/index.ts
@@ -86,6 +86,31 @@ const info = <const>{
       type: ParameterType.STRING,
       default: "#ff0000",
     },
+    /** Height of the balloon stage (the area the balloon is drawn in), in pixels. The balloon scales to fit this area. */
+    balloon_stage_height: {
+      type: ParameterType.INT,
+      default: 400,
+    },
+    /** CSS color for the value/total point numbers in the info boxes. Defaults to `currentColor` so it inherits the surrounding text color and adapts to light/dark themes. */
+    value_text_color: {
+      type: ParameterType.STRING,
+      default: "currentColor",
+    },
+    /** CSS color for the labels above the value/total point numbers. Defaults to a muted version of the surrounding text color so it adapts to light/dark themes. */
+    label_text_color: {
+      type: ParameterType.STRING,
+      default: "color-mix(in srgb, currentColor 60%, transparent)",
+    },
+    /** CSS color for the info box borders. Defaults to `currentColor` so it inherits the surrounding text color and adapts to light/dark themes. */
+    info_box_border_color: {
+      type: ParameterType.STRING,
+      default: "currentColor",
+    },
+    /** CSS color for the info box backgrounds. Defaults to a subtle tint of the surrounding text color so it adapts to light/dark themes. */
+    info_box_background_color: {
+      type: ParameterType.STRING,
+      default: "color-mix(in srgb, currentColor 6%, transparent)",
+    },
     /** Maximum expected pumps for visual scaling. The balloon will scale to fit the container at this pump count. Does not prevent pumping beyond this value. */
     max_pumps: {
       type: ParameterType.INT,
@@ -146,11 +171,19 @@ class BartPlugin implements JsPsychPlugin<Info> {
     let trial_start_time = performance.now();
     const pump_times: number[] = [];
 
-    // Calculate adjusted balloon sizing based on max_pumps to keep balloon contained
-    // At max_pumps, balloon should be roughly 350px tall (87.5% of 400px container)
+    // Calculate adjusted balloon sizing based on max_pumps to keep balloon contained.
+    // All math here is in viewBox units (the viewBox stays 300x400 regardless of the
+    // rendered balloon_stage_height). At max_pumps the balloon is ~350 units tall (87.5%
+    // of the 400-unit viewBox height).
     // Balloon height in balloon coordinates is ~300 units (from -150 to +115 with knot)
     // Target final scale at max_pumps: 350/300 ≈ 1.17
     const target_final_scale = 1.17;
+
+    // Stage dimensions. The internal SVG coordinate system (viewBox) is kept at 300x400
+    // so all the balloon/string positioning math below stays valid; only the rendered
+    // size scales with balloon_stage_height (width preserves the 300:400 = 0.75 ratio).
+    const stage_height = trial.balloon_stage_height;
+    const stage_width = stage_height * 0.75;
 
     // Keep starting size constant, only adjust increment
     const adjusted_starting_size = trial.balloon_starting_size;
@@ -168,10 +201,10 @@ class BartPlugin implements JsPsychPlugin<Info> {
           flex-wrap: wrap;
         }
         #jspsych-bart-info-container > div {
-          border: 2px solid #333;
+          border: 2px solid ${trial.info_box_border_color};
           border-radius: 8px;
           padding: 12px 24px;
-          background-color: #f0f0f0;
+          background-color: ${trial.info_box_background_color};
           min-width: 180px;
           flex: 1 1 auto;
           max-width: 250px;
@@ -211,8 +244,8 @@ class BartPlugin implements JsPsychPlugin<Info> {
         }
       </style>
       <div id="jspsych-bart-container" style="text-align: center; padding: 20px;">
-        <div id="jspsych-bart-balloon-container" style="margin: 30px auto; height: 400px; display: flex; align-items: center; justify-content: center;">
-          <svg id="jspsych-bart-balloon-svg" width="300" height="400" viewBox="0 0 300 400">
+        <div id="jspsych-bart-balloon-container" style="margin: 30px auto; height: ${stage_height}px; display: flex; align-items: center; justify-content: center;">
+          <svg id="jspsych-bart-balloon-svg" width="${stage_width}" height="${stage_height}" viewBox="0 0 300 400">
             <!-- Curved string - will be dynamically updated, placed behind balloon -->
             <path id="jspsych-bart-balloon-string"
                   d=""
@@ -251,24 +284,26 @@ class BartPlugin implements JsPsychPlugin<Info> {
           ${
             trial.show_balloon_value
               ? `<div id="jspsych-bart-balloon-value">
-              <div style="font-size: 14px; color: #666; margin-bottom: 4px;">${
-                trial.current_value_label
-              }</div>
-              <div style="font-size: 24px; font-weight: bold; color: #333;" id="jspsych-bart-balloon-value-number">${trial.point_display_format(
-                0
-              )}</div>
+              <div style="font-size: 14px; color: ${trial.label_text_color}; margin-bottom: 4px;">${
+                  trial.current_value_label
+                }</div>
+              <div style="font-size: 24px; font-weight: bold; color: ${
+                trial.value_text_color
+              };" id="jspsych-bart-balloon-value-number">${trial.point_display_format(0)}</div>
             </div>`
               : ""
           }
           ${
             trial.show_total_points
               ? `<div id="jspsych-bart-total-points">
-              <div style="font-size: 14px; color: #666; margin-bottom: 4px;">${
-                trial.total_points_label
-              }</div>
-              <div style="font-size: 24px; font-weight: bold; color: #333;" id="jspsych-bart-total-points-value">${trial.total_points_format(
-                trial.starting_total_points
-              )}</div>
+              <div style="font-size: 14px; color: ${trial.label_text_color}; margin-bottom: 4px;">${
+                  trial.total_points_label
+                }</div>
+              <div style="font-size: 24px; font-weight: bold; color: ${
+                trial.value_text_color
+              };" id="jspsych-bart-total-points-value">${trial.total_points_format(
+                  trial.starting_total_points
+                )}</div>
             </div>`
               : ""
           }


### PR DESCRIPTION
## Summary

Addresses CSS customizability issues encountered while building a BART use case. The info box styling was hard-coded (`#333`/`#666`/`#f0f0f0`) and didn't adapt to dark themes, the balloon stage height was hard-coded to `400px` (forcing `!important` overrides), and the existing `max_pumps` parameter was undocumented.

## Changes

- **Parameterize info box colors** — adds `value_text_color`, `label_text_color`, `info_box_border_color`, and `info_box_background_color`. Defaults derive from `currentColor` (via `color-mix` for the muted/tinted cases), so the display now adapts to light/dark page themes with no consumer overrides, while remaining fully overridable. Replaces the hard-coded `#333`/`#666`/`#f0f0f0` values.
- **`balloon_stage_height` parameter** (default `400`) — controls the balloon stage height. The internal SVG `viewBox` stays `0 0 300 400` so all balloon/string positioning math is unchanged; only the rendered size scales (width preserves the 0.75 aspect ratio). No more `!important` needed.
- **Document `max_pumps`** — added to the README parameters table and theming notes; added the new params to both the README and `docs/plugin-bart.md` tables and the "Customized Appearance" example.

## Testing

- `npm run build` succeeds
- All tests pass (16 existing + 4 new covering the color params, theme-adaptive defaults, and stage height)

A `minor` changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)