### PR TITLE
feat(plugin-visual-search-click-target): add fit_container for embedding

### DIFF
--- a/.changeset/visual-search-fit-container.md
+++ b/.changeset/visual-search-fit-container.md
@@ -1,0 +1,8 @@
+---
+"@jspsych-contrib/plugin-visual-search-click-target": minor
+---
+
+Make the visual search display embeddable and fix random positioning:
+
+- Add a `fit_container` parameter (default `false`). When `true`, the display fills its display element using container-relative units (cqw/cqh/cqmin) instead of covering the viewport, so the task can be embedded in a sized card or panel rather than only running full screen.
+- Fix an error on the default (random scatter) path: `image_positions` now defaults to `[]` instead of `null`, which jsPsych v8 rejects for an array parameter. Leaving it empty generates random non-overlapping positions as documented.

--- a/packages/plugin-visual-search-click-target/docs/plugin-visual-search-click-target.md
+++ b/packages/plugin-visual-search-click-target/docs/plugin-visual-search-click-target.md
@@ -15,7 +15,8 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | search_area_width   | FLOAT            | `90`               | Width of the search area as a percentage of viewport width (vw). |
 | search_area_height  | FLOAT            | `80`               | Height of the search area as a percentage of viewport height (vh). |
 | background_color    | STRING           | `"#ffffff"`        | Background color of the search display. |
-| image_positions     | ARRAY of OBJECT  | `null`             | Array of `{x, y}` objects specifying the center position of each image as percentages (0-100) of the search area. `x` is the horizontal position and `y` is the vertical position. If `null`, positions are generated randomly with non-overlapping placement. When provided, the array must have the same length as `images`. |
+| fit_container       | BOOL             | `false`            | If `true`, the search display fills its display element using container-relative units (cqw/cqh/cqmin) instead of covering the viewport. Use this to embed the task in a sized container (a card or panel) rather than running it full screen. The display element must have a defined width and height. |
+| image_positions     | ARRAY of OBJECT  | `[]`               | Array of `{x, y}` objects specifying the center position of each image as percentages (0-100) of the search area. `x` is the horizontal position and `y` is the vertical position. If left empty (the default), positions are generated randomly with non-overlapping placement. When provided, the array must have the same length as `images`. |
 
 ## Data Generated
 
@@ -105,5 +106,23 @@ var trial = {
     { x: 20, y: 30 },  // distractor upper-left area
     { x: 80, y: 70 },  // distractor lower-right area
   ],
+};
+```
+
+### Embedding in a sized container
+
+By default the task covers the viewport. Set `fit_container: true` to run it inside a sized element instead — the layout is then expressed in container-relative units, so it fills whatever element you give jsPsych as its `display_element`. That element must have a defined width and height.
+
+```javascript
+const jsPsych = initJsPsych({
+  display_element: document.getElementById('search-panel'), // e.g. a 480×360 card
+});
+
+const trial = {
+  type: jsPsychVisualSearchClickTarget,
+  images: ['img/target.png', 'img/distractor1.png', 'img/distractor2.png'],
+  target_present: true,
+  target_index: 0,
+  fit_container: true,
 };
 ```

--- a/packages/plugin-visual-search-click-target/src/index.spec.ts
+++ b/packages/plugin-visual-search-click-target/src/index.spec.ts
@@ -160,4 +160,43 @@ describe("visual-search-click-target plugin", () => {
     expect(data.image_positions[0]).toHaveProperty("x");
     expect(data.image_positions[0]).toHaveProperty("y");
   });
+
+  it("covers the viewport by default", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychPluginVisualSearchClickTarget,
+        images: ["target.png", "distractor1.png"],
+        target_present: true,
+        target_index: 0,
+      },
+    ]);
+
+    const container = displayElement.querySelector("div") as HTMLDivElement;
+    expect(container.style.position).toBe("fixed");
+
+    // Clean up
+    (displayElement.querySelector('img[data-index="0"]') as HTMLImageElement).click();
+  });
+
+  it("fills its display element when fit_container is true", async () => {
+    const { expectFinished, getData, displayElement } = await startTimeline([
+      {
+        type: jsPsychPluginVisualSearchClickTarget,
+        images: ["target.png", "distractor1.png"],
+        target_present: true,
+        target_index: 0,
+        fit_container: true,
+      },
+    ]);
+
+    // Embedded mode lays out inside the container instead of fixing to the
+    // viewport.
+    const container = displayElement.querySelector("div") as HTMLDivElement;
+    expect(container.style.position).toBe("relative");
+
+    // Still fully functional in embedded mode.
+    (displayElement.querySelector('img[data-index="0"]') as HTMLImageElement).click();
+    await expectFinished();
+    expect(getData().values()[0].correct).toBe(true);
+  });
 });

--- a/packages/plugin-visual-search-click-target/src/index.ts
+++ b/packages/plugin-visual-search-click-target/src/index.ts
@@ -42,14 +42,23 @@ const info = <const>{
       type: ParameterType.STRING,
       default: "#ffffff",
     },
+    /** If `true`, the search display fills its display element using
+     * container-relative units (cqw/cqh/cqmin) instead of covering the
+     * viewport. Use this to embed the task in a sized container (a card,
+     * a panel) rather than running it full screen. The display element must
+     * have a defined width and height. */
+    fit_container: {
+      type: ParameterType.BOOL,
+      default: false,
+    },
     /** Array of {x, y} objects specifying the position of each image as percentages (0-100)
      * of the search area dimensions. x and y specify the center of the image.
-     * If null, positions are generated randomly with non-overlapping placement.
-     * The array must have the same length as `images`. */
+     * If left empty (the default), positions are generated randomly with non-overlapping
+     * placement. When provided, the array must have the same length as `images`. */
     image_positions: {
       type: ParameterType.COMPLEX,
       array: true,
-      default: null,
+      default: [],
       nested: {
         x: {
           type: ParameterType.FLOAT,
@@ -110,9 +119,27 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     const startTime = performance.now();
 
+    // Layout units. By default the display covers the viewport (vw/vh/vmin).
+    // When `fit_container` is set, the same layout is expressed in container
+    // query units (cqw/cqh/cqmin) so it fills the display element instead.
+    const fit = trial.fit_container;
+    const uw = fit ? "cqw" : "vw";
+    const uh = fit ? "cqh" : "vh";
+    const umin = fit ? "cqmin" : "vmin";
+
     // Create container for the entire display
     const container = document.createElement("div");
-    container.style.cssText = `
+    container.style.cssText = fit
+      ? `
+      display: flex;
+      width: 100%;
+      height: 100%;
+      position: relative;
+      container-type: size;
+      overflow: hidden;
+      background: ${trial.background_color};
+    `
+      : `
       display: flex;
       width: 100vw;
       height: 100vh;
@@ -125,12 +152,12 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
     // Create absent box container (left side)
     const absentContainer = document.createElement("div");
     absentContainer.style.cssText = `
-      width: ${100 - trial.search_area_width}vw;
-      height: 100vh;
+      width: ${100 - trial.search_area_width}${uw};
+      height: 100${uh};
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      padding-left: 1vw;
+      padding-left: 1${uw};
     `;
 
     // Create absent button
@@ -138,8 +165,8 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
     absentButton.textContent = "Absent";
     absentButton.className = "jspsych-btn";
     absentButton.style.cssText = `
-      padding: 2vmin 4vmin;
-      font-size: 2vmin;
+      padding: 2${umin} 4${umin};
+      font-size: 2${umin};
       cursor: pointer;
     `;
     absentContainer.appendChild(absentButton);
@@ -147,16 +174,16 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
     // Create search area container (right side)
     const searchArea = document.createElement("div");
     searchArea.style.cssText = `
-      width: ${trial.search_area_width}vw;
-      height: ${trial.search_area_height}vh;
+      width: ${trial.search_area_width}${uw};
+      height: ${trial.search_area_height}${uh};
       position: relative;
-      margin: ${(100 - trial.search_area_height) / 2}vh 0;
+      margin: ${(100 - trial.search_area_height) / 2}${uh} 0;
     `;
 
     // Determine image positions: use custom positions if provided, otherwise generate random
     let positions: Array<{ x: number; y: number }>;
 
-    if (trial.image_positions != null) {
+    if (trial.image_positions != null && trial.image_positions.length > 0) {
       if (trial.image_positions.length !== trial.images.length) {
         throw new Error(
           `visual-search-click-target plugin: image_positions array length (${trial.image_positions.length}) ` +
@@ -181,8 +208,8 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
       img.dataset.index = index.toString();
       img.style.cssText = `
         position: absolute;
-        width: ${trial.image_size}vmin;
-        height: ${trial.image_size}vmin;
+        width: ${trial.image_size}${umin};
+        height: ${trial.image_size}${umin};
         object-fit: contain;
         left: ${positions[index].x}%;
         top: ${positions[index].y}%;


### PR DESCRIPTION
## Summary

Makes `plugin-visual-search-click-target` usable inside a sized container (a card or panel) instead of only full screen, and fixes a bug on the default random-scatter path.

- **`fit_container` parameter** (BOOL, default `false`). When `true`, the display fills its `display_element` using container-relative units (`cqw`/`cqh`/`cqmin`) instead of the viewport (`vw`/`vh`/`vmin`), and the container is `position: relative` rather than `fixed`. Default behavior is unchanged.
- **Fix random positioning.** `image_positions` defaulted to `null`, which jsPsych v8 rejects for an `array` parameter — so any trial that relied on auto-generated (random, non-overlapping) positions threw. It now defaults to `[]`, and an empty array means "generate randomly," as documented.

## Why

Embedding the task in a small page region (e.g. a homepage demo panel) previously required heavy, hook-less `!important` overrides because the layout was hard-coded to viewport units. `fit_container` expresses the same layout against the display element, so it just fills whatever sized element you hand jsPsych.

## Tests

- Added: `covers the viewport by default` and `fills its display element when fit_container is true`.
- The 5 previously-failing tests (all on the random-position path) now pass thanks to the `image_positions` fix. Full suite: **9/9 green**.

## Notes

- Backward compatible; `fit_container` defaults to the existing fullscreen behavior.
- A changeset (`minor`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)