### PR TITLE
feat(plugin-visual-search-click-target): add show_absent_button option

### DIFF
--- a/.changeset/visual-search-hide-absent.md
+++ b/.changeset/visual-search-hide-absent.md
@@ -1,0 +1,5 @@
+---
+"@jspsych-contrib/plugin-visual-search-click-target": minor
+---
+
+Add a `show_absent_button` parameter (default `true`). When set to `false`, the "Absent" button is not rendered and the search area is centered in its place — useful for target-always-present displays where an absent response isn't needed.

--- a/packages/plugin-visual-search-click-target/docs/plugin-visual-search-click-target.md
+++ b/packages/plugin-visual-search-click-target/docs/plugin-visual-search-click-target.md
@@ -16,6 +16,7 @@ In addition to the [parameters available in all plugins](https://www.jspsych.org
 | search_area_height  | FLOAT            | `80`               | Height of the search area as a percentage of viewport height (vh). |
 | background_color    | STRING           | `"#ffffff"`        | Background color of the search display. |
 | fit_container       | BOOL             | `false`            | If `true`, the search display fills its display element using container-relative units (cqw/cqh/cqmin) instead of covering the viewport. Use this to embed the task in a sized container (a card or panel) rather than running it full screen. The display element must have a defined width and height. |
+| show_absent_button  | BOOL             | `true`             | Whether to show the "Absent" button. When `false`, the button is not rendered and the search area is centered in its place. Only set this to `false` for displays where the target is always present, since there is otherwise no way to respond "absent". |
 | image_positions     | ARRAY of OBJECT  | `[]`               | Array of `{x, y}` objects specifying the center position of each image as percentages (0-100) of the search area. `x` is the horizontal position and `y` is the vertical position. If left empty (the default), positions are generated randomly with non-overlapping placement. When provided, the array must have the same length as `images`. |
 
 ## Data Generated

--- a/packages/plugin-visual-search-click-target/src/index.spec.ts
+++ b/packages/plugin-visual-search-click-target/src/index.spec.ts
@@ -199,4 +199,39 @@ describe("visual-search-click-target plugin", () => {
     await expectFinished();
     expect(getData().values()[0].correct).toBe(true);
   });
+
+  it("shows the absent button by default", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: jsPsychPluginVisualSearchClickTarget,
+        images: ["target.png", "distractor1.png"],
+        target_present: true,
+        target_index: 0,
+      },
+    ]);
+
+    expect(displayElement.querySelector("button")).not.toBeNull();
+
+    // Clean up
+    (displayElement.querySelector('img[data-index="0"]') as HTMLImageElement).click();
+  });
+
+  it("omits the absent button when show_absent_button is false", async () => {
+    const { expectFinished, getData, displayElement } = await startTimeline([
+      {
+        type: jsPsychPluginVisualSearchClickTarget,
+        images: ["target.png", "distractor1.png", "distractor2.png"],
+        target_present: true,
+        target_index: 0,
+        show_absent_button: false,
+      },
+    ]);
+
+    expect(displayElement.querySelector("button")).toBeNull();
+    // The images still render and the trial completes by clicking the target.
+    expect(displayElement.querySelectorAll("img").length).toBe(3);
+    (displayElement.querySelector('img[data-index="0"]') as HTMLImageElement).click();
+    await expectFinished();
+    expect(getData().values()[0].correct).toBe(true);
+  });
 });

--- a/packages/plugin-visual-search-click-target/src/index.ts
+++ b/packages/plugin-visual-search-click-target/src/index.ts
@@ -42,6 +42,14 @@ const info = <const>{
       type: ParameterType.STRING,
       default: "#ffffff",
     },
+    /** Whether to show the "Absent" button. When `false`, the button is not
+     * rendered and the search area is centered in its place. Only set this to
+     * `false` for displays where the target is always present, since there is
+     * otherwise no way to respond "absent". */
+    show_absent_button: {
+      type: ParameterType.BOOL,
+      default: true,
+    },
     /** If `true`, the search display fills its display element using
      * container-relative units (cqw/cqh/cqmin) instead of covering the
      * viewport. Use this to embed the task in a sized container (a card,
@@ -149,27 +157,31 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
       background: ${trial.background_color};
     `;
 
-    // Create absent box container (left side)
-    const absentContainer = document.createElement("div");
-    absentContainer.style.cssText = `
-      width: ${100 - trial.search_area_width}${uw};
-      height: 100${uh};
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-      padding-left: 1${uw};
-    `;
+    // Create the absent button and its column (left side), unless suppressed.
+    // When hidden, the search area is centered in the container instead.
+    let absentContainer: HTMLDivElement | null = null;
+    let absentButton: HTMLButtonElement | null = null;
+    if (trial.show_absent_button) {
+      absentContainer = document.createElement("div");
+      absentContainer.style.cssText = `
+        width: ${100 - trial.search_area_width}${uw};
+        height: 100${uh};
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        padding-left: 1${uw};
+      `;
 
-    // Create absent button
-    const absentButton = document.createElement("button");
-    absentButton.textContent = "Absent";
-    absentButton.className = "jspsych-btn";
-    absentButton.style.cssText = `
-      padding: 2${umin} 4${umin};
-      font-size: 2${umin};
-      cursor: pointer;
-    `;
-    absentContainer.appendChild(absentButton);
+      absentButton = document.createElement("button");
+      absentButton.textContent = "Absent";
+      absentButton.className = "jspsych-btn";
+      absentButton.style.cssText = `
+        padding: 2${umin} 4${umin};
+        font-size: 2${umin};
+        cursor: pointer;
+      `;
+      absentContainer.appendChild(absentButton);
+    }
 
     // Create search area container (right side)
     const searchArea = document.createElement("div");
@@ -220,8 +232,13 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
       searchArea.appendChild(img);
     });
 
-    // Assemble display
-    container.appendChild(absentContainer);
+    // Assemble display. With the absent column present it sits to the left of
+    // the search area; without it, the search area is centered.
+    if (absentContainer) {
+      container.appendChild(absentContainer);
+    } else {
+      container.style.justifyContent = "center";
+    }
     container.appendChild(searchArea);
     display_element.appendChild(container);
 
@@ -262,8 +279,8 @@ class VisualSearchClickTargetPlugin implements JsPsychPlugin<Info> {
       });
     });
 
-    // Add click handler to absent button
-    absentButton.addEventListener("click", () => {
+    // Add click handler to absent button (when shown)
+    absentButton?.addEventListener("click", () => {
       endTrial("absent", null);
     });
   }


### PR DESCRIPTION
## Summary

Adds a `show_absent_button` parameter (BOOL, default `true`) to `plugin-visual-search-click-target`. When `false`, the "Absent" button (and its column) is not rendered, and the search area is centered in its place.

This is useful for **target-always-present** displays — e.g. a "find and click the target" demo — where an "absent" response is meaningless and the button just consumes layout space.

## Behavior

- Default (`true`): unchanged — the absent button renders to the left of the search area.
- `false`: no absent column; the search area is centered (`justify-content: center`). The click handler is only attached when the button exists.
- Note: only set `false` when the target is always present, since there's otherwise no way to respond "absent" (documented).

## Tests

Added `shows the absent button by default` and `omits the absent button when show_absent_button is false`. Full suite **11/11 green**.

## Notes

- Backward compatible; default preserves existing behavior.
- `minor` changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)